### PR TITLE
fix: remove ./ prefix from bin path

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "npm for Agent Skills",
   "type": "module",
   "bin": {
-    "skillpm": "./dist/cli.js"
+    "skillpm": "dist/cli.js"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
npm warned about invalid bin script name during publish. Remove `./` prefix from `dist/cli.js`.