### PR TITLE
feat: skill registry page

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'scripts/generate-registry.py'
+  schedule:
+    - cron: '15 * * * *'  # hourly at :15
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -21,5 +25,8 @@ jobs:
           python-version: '3.12'
 
       - run: pip install mkdocs-material
+
+      - name: Generate skill registry
+        run: python scripts/generate-registry.py
 
       - run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 dist/
 site/
 *.tsbuildinfo
+
+# Generated registry page
+docs/registry.md

--- a/docs/assets/registry.css
+++ b/docs/assets/registry.css
@@ -1,0 +1,172 @@
+/* Skill Registry page styles */
+
+.registry-header {
+  margin-bottom: 1.5rem;
+}
+
+.registry-search-bar {
+  margin-bottom: 0.75rem;
+}
+
+#registry-search {
+  width: 100%;
+  padding: 0.6rem 1rem;
+  font-size: 1rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.5rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+#registry-search:focus {
+  border-color: var(--md-primary-fg-color);
+}
+
+.registry-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.75rem;
+}
+
+.registry-filter-btn {
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 1rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color--light);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.registry-filter-btn:hover {
+  border-color: var(--md-primary-fg-color);
+  color: var(--md-primary-fg-color);
+}
+
+.registry-filter-btn.active {
+  background: var(--md-primary-fg-color);
+  color: var(--md-primary-bg-color);
+  border-color: var(--md-primary-fg-color);
+}
+
+.registry-meta {
+  font-size: 0.85rem;
+  color: var(--md-default-fg-color--light);
+}
+
+/* Card grid */
+.registry-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1rem;
+}
+
+.registry-card {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: var(--md-default-bg-color);
+  transition: border-color 0.2s, box-shadow 0.2s;
+  display: flex;
+  flex-direction: column;
+}
+
+.registry-card:hover {
+  border-color: var(--md-primary-fg-color);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.registry-card-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.4rem;
+}
+
+.registry-card-name {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--md-primary-fg-color);
+  text-decoration: none;
+  word-break: break-all;
+}
+
+.registry-card-name:hover {
+  text-decoration: underline;
+}
+
+.registry-card-version {
+  font-size: 0.75rem;
+  color: var(--md-default-fg-color--light);
+  white-space: nowrap;
+}
+
+.registry-card-desc {
+  font-size: 0.85rem;
+  color: var(--md-default-fg-color--light);
+  margin: 0 0 0.5rem;
+  flex: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* Keyword tags */
+.registry-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-bottom: 0.5rem;
+}
+
+.registry-tag {
+  padding: 0.15rem 0.45rem;
+  font-size: 0.7rem;
+  border-radius: 0.75rem;
+  background: var(--md-code-bg-color);
+  color: var(--md-default-fg-color--light);
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+.registry-tag:hover {
+  background: var(--md-primary-fg-color);
+  color: var(--md-primary-bg-color);
+}
+
+.registry-tag.active {
+  background: var(--md-primary-fg-color);
+  color: var(--md-primary-bg-color);
+}
+
+/* Card footer */
+.registry-card-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: var(--md-default-fg-color--lighter);
+  margin-top: auto;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--md-default-fg-color--lightest);
+}
+
+/* Empty state */
+.registry-empty {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--md-default-fg-color--light);
+  font-size: 1.1rem;
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  .registry-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/docs/assets/registry.js
+++ b/docs/assets/registry.js
@@ -1,0 +1,74 @@
+/* Skill Registry — client-side search and keyword filtering */
+(function () {
+  "use strict";
+
+  var search = document.getElementById("registry-search");
+  var grid = document.getElementById("registry-grid");
+  var empty = document.getElementById("registry-empty");
+  var countEl = document.getElementById("registry-count");
+
+  if (!search || !grid) return;
+
+  var cards = Array.prototype.slice.call(grid.querySelectorAll(".registry-card"));
+  var activeKeyword = null;
+
+  function applyFilters() {
+    var query = search.value.toLowerCase().trim();
+    var visible = 0;
+
+    cards.forEach(function (card) {
+      var name = (card.getAttribute("data-name") || "").toLowerCase();
+      var desc = (card.getAttribute("data-description") || "").toLowerCase();
+      var keywords = (card.getAttribute("data-keywords") || "").toLowerCase();
+
+      var matchesSearch = !query || name.indexOf(query) !== -1 || desc.indexOf(query) !== -1;
+      var matchesKeyword =
+        !activeKeyword || keywords.split(",").indexOf(activeKeyword) !== -1;
+
+      if (matchesSearch && matchesKeyword) {
+        card.style.display = "";
+        visible++;
+      } else {
+        card.style.display = "none";
+      }
+    });
+
+    if (countEl) countEl.textContent = visible + " skill" + (visible !== 1 ? "s" : "");
+    if (empty) empty.style.display = visible === 0 ? "" : "none";
+  }
+
+  function setActiveKeyword(kw) {
+    activeKeyword = activeKeyword === kw ? null : kw;
+
+    // Update filter buttons
+    var btns = document.querySelectorAll(".registry-filter-btn");
+    btns.forEach(function (btn) {
+      btn.classList.toggle("active", btn.getAttribute("data-keyword") === activeKeyword);
+    });
+
+    // Update card tags
+    var tags = document.querySelectorAll(".registry-tag");
+    tags.forEach(function (tag) {
+      tag.classList.toggle("active", tag.getAttribute("data-keyword") === activeKeyword);
+    });
+
+    applyFilters();
+  }
+
+  // Search input
+  search.addEventListener("input", applyFilters);
+
+  // Filter button clicks
+  document.addEventListener("click", function (e) {
+    var btn = e.target.closest(".registry-filter-btn");
+    if (btn) {
+      setActiveKeyword(btn.getAttribute("data-keyword"));
+      return;
+    }
+
+    var tag = e.target.closest(".registry-tag");
+    if (tag) {
+      setActiveKeyword(tag.getAttribute("data-keyword"));
+    }
+  });
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,10 +49,17 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Skill Registry: registry.md
   - Getting Started: getting-started.md
   - Commands: commands.md
   - Creating Skills: creating-skills.md
   - Contributing: contributing.md
+
+extra_css:
+  - assets/registry.css
+
+extra_javascript:
+  - assets/registry.js
 
 extra:
   social:

--- a/scripts/generate-registry.py
+++ b/scripts/generate-registry.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Query npm registry for agent-skill packages and generate docs/registry.md."""
+
+import json
+import urllib.request
+from datetime import datetime, timezone
+from html import escape
+from pathlib import Path
+
+NPM_SEARCH_URL = "https://registry.npmjs.org/-/v1/search?text=keywords:agent-skill&size=250"
+OUTPUT_PATH = Path(__file__).parent.parent / "docs" / "registry.md"
+EXCLUDED_KEYWORDS = {"agent-skill", "ai-skill", "oneskill", "skill", "skills"}
+
+
+def fetch_packages():
+    req = urllib.request.Request(NPM_SEARCH_URL, headers={"User-Agent": "skillpm-registry-generator"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read().decode())
+    return data["objects"], data["total"]
+
+
+def format_downloads(n):
+    if n >= 1000:
+        return f"{n / 1000:.1f}k"
+    return str(n)
+
+
+def build_card(obj):
+    pkg = obj["package"]
+    name = escape(pkg["name"])
+    desc = escape(pkg.get("description", ""))
+    version = escape(pkg.get("version", ""))
+    npm_url = pkg.get("links", {}).get("npm", f"https://www.npmjs.com/package/{pkg['name']}")
+    publisher = escape(pkg.get("publisher", {}).get("username", ""))
+    weekly = obj.get("downloads", {}).get("weekly", 0)
+
+    keywords = [kw for kw in pkg.get("keywords", []) if kw.lower() not in EXCLUDED_KEYWORDS]
+    keyword_html = ""
+    if keywords:
+        tags = "".join(
+            f'<span class="registry-tag" data-keyword="{escape(kw)}">{escape(kw)}</span>'
+            for kw in keywords[:8]  # cap at 8 tags per card
+        )
+        keyword_html = f'<div class="registry-tags">{tags}</div>'
+
+    return f"""<div class="registry-card" data-name="{name}" data-description="{desc}" data-keywords="{escape(",".join(keywords))}">
+  <div class="registry-card-header">
+    <a href="{npm_url}" target="_blank" rel="noopener" class="registry-card-name">{name}</a>
+    <span class="registry-card-version">v{version}</span>
+  </div>
+  <p class="registry-card-desc">{desc}</p>
+  {keyword_html}
+  <div class="registry-card-meta">
+    <span class="registry-card-downloads" title="Weekly downloads">⬇ {format_downloads(weekly)}/wk</span>
+    <span class="registry-card-author" title="Publisher">{publisher}</span>
+  </div>
+</div>"""
+
+
+def generate():
+    packages, total = fetch_packages()
+    # Sort by weekly downloads descending
+    packages.sort(key=lambda o: o.get("downloads", {}).get("weekly", 0), reverse=True)
+
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    cards = "\n".join(build_card(obj) for obj in packages)
+
+    # Collect top keywords for filter bar
+    from collections import Counter
+    kw_counts = Counter()
+    for obj in packages:
+        for kw in obj["package"].get("keywords", []):
+            if kw.lower() not in EXCLUDED_KEYWORDS:
+                kw_counts[kw] += 1
+    top_keywords = [kw for kw, _ in kw_counts.most_common(12) if kw_counts[kw] >= 2]
+    filter_buttons = "".join(
+        f'<button class="registry-filter-btn" data-keyword="{escape(kw)}">{escape(kw)}</button>'
+        for kw in top_keywords
+    )
+
+    md = f"""---
+hide:
+  - navigation
+---
+
+# Skill Registry
+
+Browse agent skills published on npm with the `agent-skill` keyword.
+
+<div class="registry-header">
+  <div class="registry-search-bar">
+    <input type="text" id="registry-search" placeholder="Search skills..." autocomplete="off" />
+  </div>
+  <div class="registry-filters" id="registry-filters">
+    {filter_buttons}
+  </div>
+  <div class="registry-meta">
+    <span id="registry-count">{len(packages)} skills</span> · Updated {now}
+  </div>
+</div>
+
+<div class="registry-grid" id="registry-grid">
+{cards}
+</div>
+
+<div class="registry-empty" id="registry-empty" style="display:none">
+  No skills match your search.
+</div>
+"""
+
+    OUTPUT_PATH.write_text(md, encoding="utf-8")
+    print(f"Generated {OUTPUT_PATH} with {len(packages)} skills ({total} total on npm)")
+
+
+if __name__ == "__main__":
+    generate()


### PR DESCRIPTION
Adds a skill registry page to GitHub Pages that shows all npm packages with the `agent-skill` keyword.

**How it works:**
- `scripts/generate-registry.py` queries npm registry API, generates `docs/registry.md` with HTML card grid
- Docs workflow runs hourly (cron) to refresh data
- Client-side JS adds live search and clickable keyword filtering

**Each card shows:** package name, description, version, weekly downloads, publisher, keyword tags

**92 skills** currently indexed from npm.