### PR TITLE
feat: registry pagination for scaling

### DIFF
--- a/docs/assets/registry.css
+++ b/docs/assets/registry.css
@@ -164,6 +164,48 @@
   font-size: 1.1rem;
 }
 
+/* Pagination */
+.registry-pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.3rem;
+  margin-top: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.registry-page-btn {
+  padding: 0.4rem 0.7rem;
+  font-size: 0.85rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.35rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.registry-page-btn:hover:not(:disabled) {
+  border-color: var(--md-primary-fg-color);
+  color: var(--md-primary-fg-color);
+}
+
+.registry-page-btn.active {
+  background: var(--md-primary-fg-color);
+  color: var(--md-primary-bg-color);
+  border-color: var(--md-primary-fg-color);
+}
+
+.registry-page-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.registry-page-ellipsis {
+  padding: 0.4rem 0.3rem;
+  color: var(--md-default-fg-color--light);
+}
+
 /* Responsive */
 @media (max-width: 600px) {
   .registry-grid {

--- a/docs/assets/registry.js
+++ b/docs/assets/registry.js
@@ -1,54 +1,109 @@
-/* Skill Registry — client-side search and keyword filtering */
+/* Skill Registry — client-side search, keyword filtering, and pagination */
 (function () {
   "use strict";
+
+  var CARDS_PER_PAGE = 24;
 
   var search = document.getElementById("registry-search");
   var grid = document.getElementById("registry-grid");
   var empty = document.getElementById("registry-empty");
   var countEl = document.getElementById("registry-count");
+  var paginationEl = document.getElementById("registry-pagination");
 
   if (!search || !grid) return;
 
-  var cards = Array.prototype.slice.call(grid.querySelectorAll(".registry-card"));
+  var allCards = Array.prototype.slice.call(grid.querySelectorAll(".registry-card"));
   var activeKeyword = null;
+  var currentPage = 1;
+  var filteredCards = allCards;
 
-  function applyFilters() {
+  function getFilteredCards() {
     var query = search.value.toLowerCase().trim();
-    var visible = 0;
-
-    cards.forEach(function (card) {
+    return allCards.filter(function (card) {
       var name = (card.getAttribute("data-name") || "").toLowerCase();
       var desc = (card.getAttribute("data-description") || "").toLowerCase();
       var keywords = (card.getAttribute("data-keywords") || "").toLowerCase();
-
       var matchesSearch = !query || name.indexOf(query) !== -1 || desc.indexOf(query) !== -1;
-      var matchesKeyword =
-        !activeKeyword || keywords.split(",").indexOf(activeKeyword) !== -1;
+      var matchesKeyword = !activeKeyword || keywords.split(",").indexOf(activeKeyword) !== -1;
+      return matchesSearch && matchesKeyword;
+    });
+  }
 
-      if (matchesSearch && matchesKeyword) {
-        card.style.display = "";
-        visible++;
+  function renderPage() {
+    var totalPages = Math.max(1, Math.ceil(filteredCards.length / CARDS_PER_PAGE));
+    if (currentPage > totalPages) currentPage = totalPages;
+
+    var start = (currentPage - 1) * CARDS_PER_PAGE;
+    var end = start + CARDS_PER_PAGE;
+    var pageCards = new Set(filteredCards.slice(start, end));
+
+    allCards.forEach(function (card) {
+      card.style.display = pageCards.has(card) ? "" : "none";
+    });
+
+    if (countEl) countEl.textContent = filteredCards.length + " skill" + (filteredCards.length !== 1 ? "s" : "");
+    if (empty) empty.style.display = filteredCards.length === 0 ? "" : "none";
+
+    renderPagination(totalPages);
+  }
+
+  function renderPagination(totalPages) {
+    if (!paginationEl) return;
+    if (totalPages <= 1) {
+      paginationEl.innerHTML = "";
+      return;
+    }
+
+    var html = '<button class="registry-page-btn" data-page="prev" ' +
+      (currentPage <= 1 ? "disabled" : "") + '>&laquo; Prev</button>';
+
+    // Show page numbers with ellipsis for large ranges
+    var pages = getPageRange(currentPage, totalPages);
+    pages.forEach(function (p) {
+      if (p === "...") {
+        html += '<span class="registry-page-ellipsis">…</span>';
       } else {
-        card.style.display = "none";
+        html += '<button class="registry-page-btn' +
+          (p === currentPage ? " active" : "") +
+          '" data-page="' + p + '">' + p + '</button>';
       }
     });
 
-    if (countEl) countEl.textContent = visible + " skill" + (visible !== 1 ? "s" : "");
-    if (empty) empty.style.display = visible === 0 ? "" : "none";
+    html += '<button class="registry-page-btn" data-page="next" ' +
+      (currentPage >= totalPages ? "disabled" : "") + '>Next &raquo;</button>';
+
+    paginationEl.innerHTML = html;
+  }
+
+  function getPageRange(current, total) {
+    if (total <= 7) {
+      var all = [];
+      for (var i = 1; i <= total; i++) all.push(i);
+      return all;
+    }
+    var pages = [1];
+    if (current > 3) pages.push("...");
+    for (var j = Math.max(2, current - 1); j <= Math.min(total - 1, current + 1); j++) {
+      pages.push(j);
+    }
+    if (current < total - 2) pages.push("...");
+    pages.push(total);
+    return pages;
+  }
+
+  function applyFilters() {
+    currentPage = 1;
+    filteredCards = getFilteredCards();
+    renderPage();
   }
 
   function setActiveKeyword(kw) {
     activeKeyword = activeKeyword === kw ? null : kw;
 
-    // Update filter buttons
-    var btns = document.querySelectorAll(".registry-filter-btn");
-    btns.forEach(function (btn) {
+    document.querySelectorAll(".registry-filter-btn").forEach(function (btn) {
       btn.classList.toggle("active", btn.getAttribute("data-keyword") === activeKeyword);
     });
-
-    // Update card tags
-    var tags = document.querySelectorAll(".registry-tag");
-    tags.forEach(function (tag) {
+    document.querySelectorAll(".registry-tag").forEach(function (tag) {
       tag.classList.toggle("active", tag.getAttribute("data-keyword") === activeKeyword);
     });
 
@@ -58,7 +113,7 @@
   // Search input
   search.addEventListener("input", applyFilters);
 
-  // Filter button clicks
+  // Click delegation for filter buttons, tags, and pagination
   document.addEventListener("click", function (e) {
     var btn = e.target.closest(".registry-filter-btn");
     if (btn) {
@@ -69,6 +124,21 @@
     var tag = e.target.closest(".registry-tag");
     if (tag) {
       setActiveKeyword(tag.getAttribute("data-keyword"));
+      return;
+    }
+
+    var pageBtn = e.target.closest(".registry-page-btn");
+    if (pageBtn && !pageBtn.disabled) {
+      var page = pageBtn.getAttribute("data-page");
+      var totalPages = Math.ceil(filteredCards.length / CARDS_PER_PAGE);
+      if (page === "prev") currentPage = Math.max(1, currentPage - 1);
+      else if (page === "next") currentPage = Math.min(totalPages, currentPage + 1);
+      else currentPage = parseInt(page, 10);
+      renderPage();
+      grid.scrollIntoView({ behavior: "smooth", block: "start" });
     }
   });
+
+  // Initial render
+  applyFilters();
 })();

--- a/scripts/generate-registry.py
+++ b/scripts/generate-registry.py
@@ -3,20 +3,43 @@
 
 import json
 import urllib.request
+from collections import Counter
 from datetime import datetime, timezone
 from html import escape
 from pathlib import Path
 
-NPM_SEARCH_URL = "https://registry.npmjs.org/-/v1/search?text=keywords:agent-skill&size=250"
+NPM_SEARCH_URL = "https://registry.npmjs.org/-/v1/search"
+PAGE_SIZE = 250
 OUTPUT_PATH = Path(__file__).parent.parent / "docs" / "registry.md"
 EXCLUDED_KEYWORDS = {"agent-skill", "ai-skill", "oneskill", "skill", "skills"}
 
 
 def fetch_packages():
-    req = urllib.request.Request(NPM_SEARCH_URL, headers={"User-Agent": "skillpm-registry-generator"})
-    with urllib.request.urlopen(req, timeout=30) as resp:
-        data = json.loads(resp.read().decode())
-    return data["objects"], data["total"]
+    """Fetch all agent-skill packages, paginating through npm search API."""
+    all_packages = []
+    offset = 0
+    total = None
+
+    while True:
+        url = f"{NPM_SEARCH_URL}?text=keywords:agent-skill&size={PAGE_SIZE}&from={offset}"
+        req = urllib.request.Request(url, headers={"User-Agent": "skillpm-registry-generator"})
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode())
+
+        if total is None:
+            total = data["total"]
+
+        batch = data["objects"]
+        if not batch:
+            break
+
+        all_packages.extend(batch)
+        offset += len(batch)
+
+        if offset >= total:
+            break
+
+    return all_packages, total
 
 
 def format_downloads(n):
@@ -59,7 +82,6 @@ def build_card(obj):
 
 def generate():
     packages, total = fetch_packages()
-    # Sort by weekly downloads descending
     packages.sort(key=lambda o: o.get("downloads", {}).get("weekly", 0), reverse=True)
 
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
@@ -67,7 +89,6 @@ def generate():
     cards = "\n".join(build_card(obj) for obj in packages)
 
     # Collect top keywords for filter bar
-    from collections import Counter
     kw_counts = Counter()
     for obj in packages:
         for kw in obj["package"].get("keywords", []):
@@ -107,6 +128,8 @@ Browse agent skills published on npm with the `agent-skill` keyword.
 <div class="registry-empty" id="registry-empty" style="display:none">
   No skills match your search.
 </div>
+
+<div class="registry-pagination" id="registry-pagination"></div>
 """
 
     OUTPUT_PATH.write_text(md, encoding="utf-8")


### PR DESCRIPTION
Prepares the skill registry for hundreds/thousands of skills:

- **API pagination**: Generator script now loops through npm search API with offset (handles >250 results)
- **Client-side pagination**: Shows 24 cards per page with prev/next and page numbers
- Search and keyword filtering reset to page 1