### PR TITLE
feat: sort dropdown for skill registry

### DIFF
--- a/docs/assets/registry.css
+++ b/docs/assets/registry.css
@@ -4,8 +4,14 @@
   margin-bottom: 1.5rem;
 }
 
-.registry-search-bar {
+.registry-controls {
+  display: flex;
+  gap: 0.75rem;
   margin-bottom: 0.75rem;
+}
+
+.registry-search-bar {
+  flex: 1;
 }
 
 #registry-search {
@@ -21,6 +27,22 @@
 }
 
 #registry-search:focus {
+  border-color: var(--md-primary-fg-color);
+}
+
+.registry-sort select {
+  padding: 0.6rem 0.75rem;
+  font-size: 1rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.5rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.registry-sort select:focus {
   border-color: var(--md-primary-fg-color);
 }
 

--- a/docs/assets/registry.js
+++ b/docs/assets/registry.js
@@ -1,10 +1,11 @@
-/* Skill Registry — client-side search, keyword filtering, and pagination */
+/* Skill Registry — client-side search, keyword filtering, sorting, and pagination */
 (function () {
   "use strict";
 
   var CARDS_PER_PAGE = 24;
 
   var search = document.getElementById("registry-search");
+  var sortSelect = document.getElementById("registry-sort-select");
   var grid = document.getElementById("registry-grid");
   var empty = document.getElementById("registry-empty");
   var countEl = document.getElementById("registry-count");
@@ -13,13 +14,30 @@
   if (!search || !grid) return;
 
   var allCards = Array.prototype.slice.call(grid.querySelectorAll(".registry-card"));
+  // Preserve the original (npm score) order
+  allCards.forEach(function (card, i) { card._originalIndex = i; });
+
   var activeKeyword = null;
   var currentPage = 1;
   var filteredCards = allCards;
 
+  var sortFns = {
+    score: function (a, b) { return a._originalIndex - b._originalIndex; },
+    downloads: function (a, b) {
+      return (parseFloat(b.getAttribute("data-downloads")) || 0) -
+             (parseFloat(a.getAttribute("data-downloads")) || 0);
+    },
+    updated: function (a, b) {
+      return (b.getAttribute("data-updated") || "").localeCompare(a.getAttribute("data-updated") || "");
+    },
+    name: function (a, b) {
+      return (a.getAttribute("data-name") || "").localeCompare(b.getAttribute("data-name") || "");
+    }
+  };
+
   function getFilteredCards() {
     var query = search.value.toLowerCase().trim();
-    return allCards.filter(function (card) {
+    var result = allCards.filter(function (card) {
       var name = (card.getAttribute("data-name") || "").toLowerCase();
       var desc = (card.getAttribute("data-description") || "").toLowerCase();
       var keywords = (card.getAttribute("data-keywords") || "").toLowerCase();
@@ -27,6 +45,12 @@
       var matchesKeyword = !activeKeyword || keywords.split(",").indexOf(activeKeyword) !== -1;
       return matchesSearch && matchesKeyword;
     });
+
+    var sortKey = sortSelect ? sortSelect.value : "score";
+    var fn = sortFns[sortKey] || sortFns.score;
+    result.sort(fn);
+
+    return result;
   }
 
   function renderPage() {
@@ -39,6 +63,11 @@
 
     allCards.forEach(function (card) {
       card.style.display = pageCards.has(card) ? "" : "none";
+    });
+
+    // Re-order DOM to match sort
+    filteredCards.slice(start, end).forEach(function (card) {
+      grid.appendChild(card);
     });
 
     if (countEl) countEl.textContent = filteredCards.length + " skill" + (filteredCards.length !== 1 ? "s" : "");
@@ -57,7 +86,6 @@
     var html = '<button class="registry-page-btn" data-page="prev" ' +
       (currentPage <= 1 ? "disabled" : "") + '>&laquo; Prev</button>';
 
-    // Show page numbers with ellipsis for large ranges
     var pages = getPageRange(currentPage, totalPages);
     pages.forEach(function (p) {
       if (p === "...") {
@@ -112,6 +140,9 @@
 
   // Search input
   search.addEventListener("input", applyFilters);
+
+  // Sort dropdown
+  if (sortSelect) sortSelect.addEventListener("change", applyFilters);
 
   // Click delegation for filter buttons, tags, and pagination
   document.addEventListener("click", function (e) {

--- a/scripts/generate-registry.py
+++ b/scripts/generate-registry.py
@@ -56,17 +56,19 @@ def build_card(obj):
     npm_url = pkg.get("links", {}).get("npm", f"https://www.npmjs.com/package/{pkg['name']}")
     publisher = escape(pkg.get("publisher", {}).get("username", ""))
     weekly = obj.get("downloads", {}).get("weekly", 0)
+    score = obj.get("score", {}).get("final", 0)
+    updated = pkg.get("date", "")
 
     keywords = [kw for kw in pkg.get("keywords", []) if kw.lower() not in EXCLUDED_KEYWORDS]
     keyword_html = ""
     if keywords:
         tags = "".join(
             f'<span class="registry-tag" data-keyword="{escape(kw)}">{escape(kw)}</span>'
-            for kw in keywords[:8]  # cap at 8 tags per card
+            for kw in keywords[:8]
         )
         keyword_html = f'<div class="registry-tags">{tags}</div>'
 
-    return f"""<div class="registry-card" data-name="{name}" data-description="{desc}" data-keywords="{escape(",".join(keywords))}">
+    return f"""<div class="registry-card" data-name="{name}" data-description="{desc}" data-keywords="{escape(",".join(keywords))}" data-downloads="{weekly}" data-updated="{escape(updated)}" data-score="{score}">
   <div class="registry-card-header">
     <a href="{npm_url}" target="_blank" rel="noopener" class="registry-card-name">{name}</a>
     <span class="registry-card-version">v{version}</span>
@@ -110,8 +112,18 @@ hide:
 Browse agent skills published on npm with the `agent-skill` keyword.
 
 <div class="registry-header">
-  <div class="registry-search-bar">
-    <input type="text" id="registry-search" placeholder="Search skills..." autocomplete="off" />
+  <div class="registry-controls">
+    <div class="registry-search-bar">
+      <input type="text" id="registry-search" placeholder="Search skills..." autocomplete="off" />
+    </div>
+    <div class="registry-sort">
+      <select id="registry-sort-select">
+        <option value="score">Relevance</option>
+        <option value="downloads">Downloads</option>
+        <option value="updated">Recently updated</option>
+        <option value="name">Name</option>
+      </select>
+    </div>
   </div>
   <div class="registry-filters" id="registry-filters">
     {filter_buttons}


### PR DESCRIPTION
Adds a sort dropdown with 4 options: Relevance (npm score), Downloads, Recently updated, Name. Sort data attributes emitted by the generator, sorting done client-side.