### PR TITLE
docs: add author CTAs and cross-navigation

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -73,7 +73,7 @@ skillpm publish
 skillpm publish --access public    # for scoped packages
 ```
 
-Validates that `"agent-skill"` is present in `package.json` `keywords`, then delegates to `npm publish`. Your skill will be discoverable via [`keywords:agent-skill`](https://www.npmjs.com/search?q=keywords:agent-skill) on npmjs.org.
+Validates that `"agent-skill"` is present in `package.json` `keywords`, runs [`skills-ref validate`](https://github.com/agentskills/agentskills/tree/main/skills-ref) against the [Agent Skills spec](https://agentskills.io/specification), then delegates to `npm publish`. Your skill will appear in the [Skill Registry](registry.md) and on [npmjs.org](https://www.npmjs.com/search?q=keywords:agent-skill).
 
 ---
 

--- a/docs/creating-skills.md
+++ b/docs/creating-skills.md
@@ -1,5 +1,7 @@
 # Creating Skills
 
+Skills follow the open [Agent Skills spec](https://agentskills.io/specification). skillpm adds npm packaging conventions on top.
+
 ## Package structure
 
 A skill is a standard npm package with the skill content in a `skills/<name>/` subdirectory:
@@ -120,3 +122,20 @@ skillpm publish --access public
 ```
 
 The skill directory name should be the unscoped name (e.g., `skills/my-skill/`).
+
+## Validate before publishing
+
+Use the [skills-ref](https://github.com/agentskills/agentskills/tree/main/skills-ref) validator to check your SKILL.md against the spec:
+
+```bash
+npx skills-ref validate skills/<name>
+```
+
+`skillpm publish` runs this automatically.
+
+## Resources
+
+- [Agent Skills spec](https://agentskills.io/specification) — the open standard for SKILL.md format
+- [Example skills](https://github.com/anthropics/skills) — official examples from Anthropic
+- [Skill Registry](registry.md) — browse published skills for inspiration
+- [skillpm Commands](commands.md) — full CLI reference

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,5 +51,6 @@ This adds the skills as standard npm dependencies in `package.json`. Anyone who 
 
 ## What's next?
 
+- [Skill Registry](registry.md) — browse available skills
 - [Commands](commands.md) — full reference for all skillpm commands
 - [Creating Skills](creating-skills.md) — build and publish your own skill package

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,10 @@ When you run `skillpm install <skill>`:
 
 That's it. Agents see the full skill tree with MCP servers configured.
 
+## Browse skills
+
+Explore available skills in the [Skill Registry](registry.md), or search directly on [npmjs.org](https://www.npmjs.com/search?q=keywords:agent-skill).
+
 ## Why skillpm?
 
 The [Agent Skills spec](https://agentskills.io) defines what a skill is — but not how to publish, install, version, or share them.
@@ -57,3 +61,12 @@ The [Agent Skills spec](https://agentskills.io) defines what a skill is — but 
 | No versioning | npm semver, `package-lock.json`, reproducible installs |
 | No agent wiring | Auto-links skills into agent directories via [`skills`](https://www.npmjs.com/package/skills) |
 | No MCP server config | Collects and configures MCP servers transitively via [`add-mcp`](https://github.com/neondatabase/add-mcp) |
+
+## Create your own skill
+
+Ready to build and share a skill? See the [Creating Skills](creating-skills.md) guide — or just run:
+
+```bash
+mkdir my-skill && cd my-skill
+skillpm init
+```

--- a/scripts/generate-registry.py
+++ b/scripts/generate-registry.py
@@ -142,6 +142,9 @@ Browse agent skills published on npm with the `agent-skill` keyword.
 </div>
 
 <div class="registry-pagination" id="registry-pagination"></div>
+
+!!! tip "Want to publish your own skill?"
+    See the [Creating Skills](creating-skills.md) guide for the full packaging spec, or run `skillpm init` to scaffold a new skill package in seconds. Skills follow the open [Agent Skills spec](https://agentskills.io/specification).
 """
 
     OUTPUT_PATH.write_text(md, encoding="utf-8")


### PR DESCRIPTION
Adds prominent links to help skill authors find the packaging guide, the Agent Skills spec, and the registry across all doc pages.