### PR TITLE
feat: support legacy skill packages (root SKILL.md)

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -40,6 +40,11 @@ export async function wireSkills(cwd: string): Promise<void> {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(`Failed to link ${skill.name}: ${msg}`);
     }
+    if (skill.legacy) {
+      log.warn(
+        `${skill.name}: SKILL.md is at package root. Move to skills/<name>/SKILL.md for full compatibility. See https://sbroenne.github.io/skillpm/creating-skills/`,
+      );
+    }
   }
 
   // Collect and configure MCP servers

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -15,7 +15,8 @@ export async function list(cwd: string): Promise<void> {
   for (const skill of skills) {
     const frontmatter = await readSkillMd(skill.skillDir);
     const description = frontmatter?.description ?? '';
-    console.log(`  ${log.skill(skill.name, skill.version)}`);
+    const legacyTag = skill.legacy ? ' (legacy)' : '';
+    console.log(`  ${log.skill(skill.name, skill.version)}${legacyTag}`);
     if (description) {
       console.log(`    ${description}`);
     }

--- a/src/manifest/schema.ts
+++ b/src/manifest/schema.ts
@@ -21,7 +21,9 @@ export interface SkillInfo {
   name: string;
   version: string;
   path: string;
-  /** Path to the skills/<name>/ subdirectory containing SKILL.md */
+  /** Path to the directory containing SKILL.md */
   skillDir: string;
   mcpServers: string[];
+  /** True if SKILL.md is at package root instead of skills/<name>/ */
+  legacy?: boolean;
 }

--- a/src/scanner/index.test.ts
+++ b/src/scanner/index.test.ts
@@ -87,7 +87,7 @@ describe('scanNodeModules', () => {
     expect(result[0].mcpServers).toEqual(['@anthropic/mcp-server-filesystem']);
   });
 
-  it('ignores packages with root SKILL.md but no skills/ dir', async () => {
+  it('detects root SKILL.md as legacy skill', async () => {
     const pkgDir = join(tmpDir, 'node_modules', 'old-skill');
     await mkdir(pkgDir, { recursive: true });
     await writeFile(
@@ -97,7 +97,27 @@ describe('scanNodeModules', () => {
     await writeFile(join(pkgDir, 'SKILL.md'), '---\nname: old-skill\n---\n');
 
     const result = await scanNodeModules(tmpDir);
-    expect(result).toEqual([]);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('old-skill');
+    expect(result[0].skillDir).toBe(pkgDir);
+    expect(result[0].legacy).toBe(true);
+  });
+
+  it('prefers skills/<name>/SKILL.md over root SKILL.md', async () => {
+    const pkgDir = join(tmpDir, 'node_modules', 'dual-skill');
+    const skillDir = join(pkgDir, 'skills', 'dual-skill');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ name: 'dual-skill', version: '1.0.0' }),
+    );
+    await writeFile(join(pkgDir, 'SKILL.md'), '---\nname: dual-skill\n---\n');
+    await writeFile(join(skillDir, 'SKILL.md'), '---\nname: dual-skill\n---\n');
+
+    const result = await scanNodeModules(tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].skillDir).toBe(skillDir);
+    expect(result[0].legacy).toBeUndefined();
   });
 });
 

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -49,13 +49,13 @@ async function tryReadSkill(pkgDir: string): Promise<SkillInfo | null> {
   const pkg = await readPackageJson(pkgDir);
   if (!pkg) return null;
 
-  // Look for skills/*/SKILL.md
+  // Preferred: look for skills/*/SKILL.md
   const skillsDir = join(pkgDir, 'skills');
   let skillSubdirs: string[];
   try {
     skillSubdirs = await readdir(skillsDir);
   } catch {
-    return null;
+    skillSubdirs = [];
   }
 
   for (const sub of skillSubdirs) {
@@ -76,7 +76,22 @@ async function tryReadSkill(pkgDir: string): Promise<SkillInfo | null> {
     };
   }
 
-  return null;
+  // Fallback: root SKILL.md (legacy format)
+  try {
+    await access(join(pkgDir, 'SKILL.md'));
+  } catch {
+    return null;
+  }
+
+  const skillpm = parseSkillpmField(pkg);
+  return {
+    name: pkg.name,
+    version: pkg.version,
+    path: pkgDir,
+    skillDir: pkgDir,
+    mcpServers: skillpm?.mcpServers ?? [],
+    legacy: true,
+  };
 }
 
 /**


### PR DESCRIPTION
Adds fallback support for the 70+ npm packages that have SKILL.md at the package root instead of `skills/<name>/SKILL.md`.

**What changes:**
- Scanner checks `skills/*/SKILL.md` first (preferred), then falls back to root `SKILL.md`
- Legacy skills get a warning during install pointing to the packaging guide
- `skillpm list` shows `(legacy)` tag
- `skills/<name>/` always takes priority if both exist

**25 tests pass** (2 new: legacy detection + priority ordering)