### PR TITLE
docs: Agent Skills Registry + SEO meta descriptions

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,3 +1,7 @@
+---
+description: Full reference for all skillpm CLI commands — install, uninstall, list, init, publish, sync, and MCP server configuration.
+---
+
 # Commands
 
 ## `skillpm install [skill...]`
@@ -73,7 +77,7 @@ skillpm publish
 skillpm publish --access public    # for scoped packages
 ```
 
-Validates that `"agent-skill"` is present in `package.json` `keywords`, runs [`skills-ref validate`](https://github.com/agentskills/agentskills/tree/main/skills-ref) against the [Agent Skills spec](https://agentskills.io/specification), then delegates to `npm publish`. Your skill will appear in the [Skill Registry](registry.md) and on [npmjs.org](https://www.npmjs.com/search?q=keywords:agent-skill).
+Validates that `"agent-skill"` is present in `package.json` `keywords`, runs [`skills-ref validate`](https://github.com/agentskills/agentskills/tree/main/skills-ref) against the [Agent Skills spec](https://agentskills.io/specification), then delegates to `npm publish`. Your skill will appear in the [Agent Skills Registry](registry.md) and on [npmjs.org](https://www.npmjs.com/search?q=keywords:agent-skill).
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,3 +1,7 @@
+---
+description: Set up a development environment for contributing to skillpm. Includes project structure, conventions, and testing.
+---
+
 # Contributing
 
 ## Development setup

--- a/docs/creating-skills.md
+++ b/docs/creating-skills.md
@@ -1,3 +1,7 @@
+---
+description: How to create, package, validate, and publish an agent skill to npm. Includes the SKILL.md format, package structure, and publishing checklist.
+---
+
 # Creating Skills
 
 Skills follow the open [Agent Skills spec](https://agentskills.io/specification). skillpm adds npm packaging conventions on top.
@@ -137,5 +141,5 @@ npx skills-ref validate skills/<name>
 
 - [Agent Skills spec](https://agentskills.io/specification) — the open standard for SKILL.md format
 - [Example skills](https://github.com/anthropics/skills) — official examples from Anthropic
-- [Skill Registry](registry.md) — browse published skills for inspiration
+- [Agent Skills Registry](registry.md) — browse published skills for inspiration
 - [skillpm Commands](commands.md) — full CLI reference

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,7 @@
+---
+description: Install skillpm and start using agent skills in your projects. Works with npx or as a global install.
+---
+
 # Getting Started
 
 ## Installation
@@ -51,6 +55,6 @@ This adds the skills as standard npm dependencies in `package.json`. Anyone who 
 
 ## What's next?
 
-- [Skill Registry](registry.md) — browse available skills
+- [Agent Skills Registry](registry.md) — browse available skills
 - [Commands](commands.md) — full reference for all skillpm commands
 - [Creating Skills](creating-skills.md) — build and publish your own skill package

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+description: "skillpm — npm for Agent Skills. Install, manage, and publish agent skills with full dependency resolution, agent wiring, and MCP server configuration."
+---
+
 # skillpm
 
 **npm for Agent Skills.**
@@ -47,7 +51,7 @@ That's it. Agents see the full skill tree with MCP servers configured.
 
 ## Browse skills
 
-Explore available skills in the [Skill Registry](registry.md), or search directly on [npmjs.org](https://www.npmjs.com/search?q=keywords:agent-skill).
+Explore available skills in the [Agent Skills Registry](registry.md), or search directly on [npmjs.org](https://www.npmjs.com/search?q=keywords:agent-skill).
 
 ## Why skillpm?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Skill Registry: registry.md
+  - Agent Skills Registry: registry.md
   - Getting Started: getting-started.md
   - Commands: commands.md
   - Creating Skills: creating-skills.md
@@ -60,6 +60,10 @@ extra_css:
 
 extra_javascript:
   - assets/registry.js
+
+plugins:
+  - search
+  - meta
 
 extra:
   social:

--- a/scripts/generate-registry.py
+++ b/scripts/generate-registry.py
@@ -105,9 +105,10 @@ def generate():
     md = f"""---
 hide:
   - navigation
+description: Browse and search all agent skills published on npm. Find skills for Claude, Cursor, VS Code, Codex, and other AI agents.
 ---
 
-# Skill Registry
+# Agent Skills Registry
 
 Browse agent skills published on npm with the `agent-skill` keyword.
 


### PR DESCRIPTION
- Renames 'Skill Registry' to 'Agent Skills Registry' in nav, title, and all cross-links
- Adds `description` frontmatter to every doc page for SEO
- Enables `meta` plugin in mkdocs.yml