### PR TITLE
feat: Open Graph and Twitter Card meta tags

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ repo_url: https://github.com/sbroenne/skillpm
 
 theme:
   name: material
+  custom_dir: overrides
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {% set desc = page.meta.description if page and page.meta and page.meta.description else config.site_description %}
+  {% set title = page.title if page.title and page.title != "Home" else config.site_name %}
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="{{ title }}" />
+  <meta property="og:description" content="{{ desc }}" />
+  <meta property="og:url" content="{{ page.canonical_url }}" />
+  <meta property="og:site_name" content="{{ config.site_name }}" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="{{ title }}" />
+  <meta name="twitter:description" content="{{ desc }}" />
+{% endblock %}


### PR DESCRIPTION
Adds OG and Twitter Card tags to all pages using a theme override (no Insiders needed). Uses per-page `description` frontmatter with fallback to site description.