### PR TITLE
fix: add robots.txt for search engine indexing

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://skillpm.dev/sitemap.xml


### PR DESCRIPTION
Google Search Console can't find the sitemap because there's no `robots.txt`. Adds `docs/robots.txt` pointing to `https://skillpm.dev/sitemap.xml`.