### PR TITLE
docs: attribute agent wiring and MCP config to delegated tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# skillpm — npm for Agent Skills
+# skillpm — Package manager for Agent Skills. Built on npm.
 
 [![npm](https://img.shields.io/npm/v/skillpm)](https://www.npmjs.com/package/skillpm)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -6,7 +6,7 @@
 
 The [Agent Skills spec](https://agentskills.io) defines what a skill is — but not how to publish, install, version, or share them. There's no registry, no dependency management, no way for one skill to build on another.
 
-**skillpm** fills that gap by mapping Agent Skills onto npm's ecosystem. Same `package.json`, same `node_modules/`, same registry. Skills become npm packages you can publish, install, version, and depend on — just like any other package.
+**skillpm** fills that gap. It's a lightweight orchestration layer — ~630 lines of code, 3 runtime dependencies — that maps Agent Skills onto npm's ecosystem. Same `package.json`, same `node_modules/`, same registry. Skills become npm packages you can publish, install, version, and depend on — just like any other package.
 
 ## Quick start
 
@@ -33,12 +33,14 @@ When you run `skillpm install <skill>`:
 
 1. **npm install** — npm handles resolution, download, lockfile, `node_modules/`
 2. **Scan** — skillpm scans `node_modules/` for packages containing `skills/*/SKILL.md`
-3. **Link** — for each skill found, skillpm calls [`skills`](https://www.npmjs.com/package/skills) to wire it into 37+ agent directories (Claude, Cursor, VS Code, Codex, etc.)
+3. **Link** — for each skill found, skillpm calls [`skills`](https://www.npmjs.com/package/skills) to wire it into agent directories (Claude, Cursor, VS Code, Codex, and many more)
 4. **MCP config** — skillpm collects `skillpm.mcpServers` from all skills (transitively) and configures each via [`add-mcp`](https://github.com/neondatabase/add-mcp)
 
 That's it. Agents see the full skill tree with MCP servers configured.
 
 ## What's missing from the spec — and what skillpm adds
+
+skillpm doesn't reinvent anything. It orchestrates three battle-tested tools: npm, [`skills`](https://www.npmjs.com/package/skills), and [`add-mcp`](https://github.com/neondatabase/add-mcp).
 
 | The spec doesn't define... | skillpm adds... |
 |---|---|
@@ -46,7 +48,7 @@ That's it. Agents see the full skill tree with MCP servers configured.
 | An install command | `skillpm install` resolves the full dependency tree |
 | Dependency management | Standard `package.json` `dependencies` — npm handles semver, lockfiles, audit |
 | Versioning | npm semver, `package-lock.json`, reproducible installs |
-| Agent wiring | Auto-links skills into 37+ agent directories via [`skills`](https://www.npmjs.com/package/skills) |
+| Agent wiring | Links skills into agent directories via [`skills`](https://www.npmjs.com/package/skills) |
 | MCP server config | Collects and configures MCP servers transitively via [`add-mcp`](https://github.com/neondatabase/add-mcp) |
 
 ## Commands

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,8 +30,8 @@ This will:
 
 1. Install the skill (and all its dependencies) via npm
 2. Scan for skill packages in `node_modules/`
-3. Link each skill into your agent directories (Claude, Cursor, VS Code, Codex, etc.)
-4. Configure any MCP servers declared by the skills
+3. Link each skill into agent directories via [`skills`](https://www.npmjs.com/package/skills) (Claude, Cursor, VS Code, Codex, and many more)
+4. Configure any MCP servers declared by the skills via [`add-mcp`](https://github.com/neondatabase/add-mcp)
 
 ## Verify it worked
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,21 +1,21 @@
 ---
-description: "skillpm — npm for Agent Skills. Install, manage, and publish agent skills with full dependency resolution, agent wiring, and MCP server configuration."
+description: "skillpm — Package manager for Agent Skills. Built on npm. ~630 lines of code, 3 dependencies, zero reinvention."
 ---
 
 # skillpm
 
-**npm for Agent Skills.**
+**Package manager for Agent Skills. Built on npm.**
 
 The [Agent Skills spec](https://agentskills.io) defines what a skill is — but not how to publish, install, version, or share them. There's no registry, no dependency management, no way for one skill to build on another.
 
-**skillpm** fills that gap by mapping Agent Skills onto npm's ecosystem. Skills become packages you can publish, install, version, and depend on — just like any other npm package.
+**skillpm** fills that gap. It's a lightweight orchestration layer — ~630 lines of code, 3 runtime dependencies — that maps Agent Skills onto npm's ecosystem. Skills become packages you can publish, install, version, and depend on — just like any other npm package.
 
 <div class="grid cards" markdown>
 
 - :material-download: **Install skills** — `skillpm install <skill>` resolves the full dependency tree in one step
 - :material-tree: **Dependency management** — skills can depend on other skills, with full semver and lockfile support
-- :material-link: **Agent wiring** — auto-links skills into 37+ agent directories (Claude, Cursor, VS Code, Codex, etc.)
-- :material-server: **MCP servers** — collects and configures MCP servers declared by skills, transitively
+- :material-link: **Agent wiring** — links skills into agent directories via [`skills`](https://www.npmjs.com/package/skills) (Claude, Cursor, VS Code, Codex, and many more)
+- :material-server: **MCP servers** — configures MCP servers declared by skills via [`add-mcp`](https://github.com/neondatabase/add-mcp), transitively
 
 </div>
 
@@ -63,8 +63,8 @@ The [Agent Skills spec](https://agentskills.io) defines what a skill is — but 
 | No install command | `skillpm install` resolves the full dependency tree |
 | No dependency management | Standard `package.json` `dependencies` — npm handles semver, lockfiles, audit |
 | No versioning | npm semver, `package-lock.json`, reproducible installs |
-| No agent wiring | Auto-links skills into agent directories via [`skills`](https://www.npmjs.com/package/skills) |
-| No MCP server config | Collects and configures MCP servers transitively via [`add-mcp`](https://github.com/neondatabase/add-mcp) |
+| No agent wiring | Links skills into agent directories via [`skills`](https://www.npmjs.com/package/skills) |
+| No MCP server config | Configures MCP servers transitively via [`add-mcp`](https://github.com/neondatabase/add-mcp) |
 
 ## Create your own skill
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: skillpm
 site_url: https://skillpm.dev
-site_description: npm for Agent Skills
+site_description: "Package manager for Agent Skills. Built on npm."
 site_author: sbroenne
 
 repo_name: sbroenne/skillpm

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skillpm",
   "version": "0.0.1",
-  "description": "npm for Agent Skills",
+  "description": "Package manager for Agent Skills. Built on npm.",
   "type": "module",
   "bin": {
     "skillpm": "dist/cli.js"


### PR DESCRIPTION
Fixes docs across README, homepage, getting started, and dev.to post to clearly attribute:

- **Agent directory wiring** → [`skills`](https://www.npmjs.com/package/skills) (Vercel)
- **MCP server configuration** → [`add-mcp`](https://github.com/neondatabase/add-mcp) (Neon)

Removes hard-coded '37+' agent count (that number belongs to the `skills` package and may change). skillpm orchestrates these tools — it doesn't reimplement them.

Also adds the dev.to blog post draft (`devto-post.md`).