### PR TITLE
fix: add CNAME for skillpm.dev custom domain

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+skillpm.dev


### PR DESCRIPTION
skillpm.dev is down — mkdocs gh-deploy --force wipes the CNAME file each deploy.