### PR TITLE
fix: wire global skills into home directory, not npm prefix

### DIFF
--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+vi.mock('../utils/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/index.js')>();
+  return {
+    ...actual,
+    npm: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+    npx: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+  };
+});
+
+import { npx } from '../utils/index.js';
+import { wireSkills } from './install.js';
+
+const mockNpx = vi.mocked(npx);
+
+async function createTmpDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'skillpm-install-'));
+}
+
+async function setupSkillPackage(nodeModulesDir: string, name: string): Promise<void> {
+  const pkgDir = join(nodeModulesDir, name);
+  const skillDir = join(pkgDir, 'skills', name);
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(
+    join(pkgDir, 'package.json'),
+    JSON.stringify({ name, version: '1.0.0' }),
+  );
+  await writeFile(
+    join(skillDir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: Test\n---\n# ${name}\n`,
+  );
+}
+
+describe('wireSkills', () => {
+  let scanRoot: string;
+  let wireTarget: string;
+
+  beforeEach(async () => {
+    scanRoot = await createTmpDir();
+    wireTarget = await createTmpDir();
+    mockNpx.mockClear();
+  });
+
+  afterEach(async () => {
+    await rm(scanRoot, { recursive: true, force: true });
+    await rm(wireTarget, { recursive: true, force: true });
+  });
+
+  it('uses wireTarget directory for skills add, not scanRoot', async () => {
+    await setupSkillPackage(join(scanRoot, 'node_modules'), 'test-skill');
+    await wireSkills(scanRoot, wireTarget);
+
+    // skills add should be called with wireTarget as cwd
+    const skillsAddCall = mockNpx.mock.calls.find(
+      (call) => call[0][0] === 'skills' && call[0][1] === 'add',
+    );
+    expect(skillsAddCall).toBeDefined();
+    expect(skillsAddCall![1]).toEqual({ cwd: wireTarget });
+  });
+
+  it('defaults wireTarget to scanRoot when not provided', async () => {
+    await setupSkillPackage(join(scanRoot, 'node_modules'), 'test-skill');
+    await wireSkills(scanRoot);
+
+    const skillsAddCall = mockNpx.mock.calls.find(
+      (call) => call[0][0] === 'skills' && call[0][1] === 'add',
+    );
+    expect(skillsAddCall).toBeDefined();
+    expect(skillsAddCall![1]).toEqual({ cwd: scanRoot });
+  });
+});

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -3,16 +3,19 @@ import { scanNodeModules, collectMcpServers } from '../scanner/index.js';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { dirname } from 'node:path';
+import { homedir } from 'node:os';
 
 const execFileAsync = promisify(execFile);
 
+function isGlobalFlag(args: string[]): boolean {
+  return args.includes('-g') || args.includes('--global');
+}
+
 /**
- * Resolve the root directory for scanning. For global installs, uses `npm root -g`.
+ * Resolve the node_modules root to scan. For global installs, uses `npm root -g`.
  */
 async function resolveNodeModulesRoot(args: string[], cwd: string): Promise<string> {
-  const isGlobal = args.includes('-g') || args.includes('--global');
-  if (!isGlobal) return cwd;
-
+  if (!isGlobalFlag(args)) return cwd;
   const { stdout } = await execFileAsync('npm', ['root', '-g']);
   return dirname(stdout.trim());
 }
@@ -33,12 +36,16 @@ export async function install(args: string[], cwd: string): Promise<void> {
 
   // Step 2: Scan for skills and wire them
   const scanRoot = await resolveNodeModulesRoot(args, cwd);
-  await wireSkills(scanRoot);
+  // For global installs, wire skills into user's home directory (not the npm prefix)
+  const wireTarget = isGlobalFlag(args) ? homedir() : cwd;
+  await wireSkills(scanRoot, wireTarget);
 }
 
-export async function wireSkills(cwd: string): Promise<void> {
+export async function wireSkills(scanRoot: string, wireTarget?: string): Promise<void> {
+  const wireCwd = wireTarget ?? scanRoot;
+
   // Scan node_modules/ for SKILL.md packages
-  const skills = await scanNodeModules(cwd);
+  const skills = await scanNodeModules(scanRoot);
 
   if (skills.length === 0) {
     log.info('No skill packages found in node_modules/');
@@ -51,7 +58,7 @@ export async function wireSkills(cwd: string): Promise<void> {
   for (const skill of skills) {
     log.info(`Linking ${log.skill(skill.name, skill.version)} into agent directories`);
     try {
-      await npx(['skills', 'add', skill.skillDir, '--all', '-y'], { cwd });
+      await npx(['skills', 'add', skill.skillDir, '--all', '-y'], { cwd: wireCwd });
       log.success(`Linked ${skill.name}`);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -71,7 +78,7 @@ export async function wireSkills(cwd: string): Promise<void> {
     for (const server of mcpServers) {
       log.info(`Configuring MCP server: ${server}`);
       try {
-        await npx(['add-mcp', server, '-y'], { cwd });
+        await npx(['add-mcp', server, '-y'], { cwd: wireCwd });
         log.success(`Configured ${server}`);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -85,7 +92,7 @@ export async function wireSkills(cwd: string): Promise<void> {
     for (const agentFile of skill.agents) {
       log.info(`Wiring agent from ${log.skill(skill.name, skill.version)}`);
       try {
-        await npx(['add-agent', agentFile, '--package', skill.name], { cwd });
+        await npx(['add-agent', agentFile, '--package', skill.name], { cwd: wireCwd });
         log.success(`Wired agent ${agentFile}`);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -99,7 +106,7 @@ export async function wireSkills(cwd: string): Promise<void> {
     for (const promptFile of skill.prompts) {
       log.info(`Wiring prompt from ${log.skill(skill.name, skill.version)}`);
       try {
-        await npx(['add-prompt', promptFile, '--package', skill.name], { cwd });
+        await npx(['add-prompt', promptFile, '--package', skill.name], { cwd: wireCwd });
         log.success(`Wired prompt ${promptFile}`);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Global installs (`-g`) were wiring skills into the npm prefix directory (e.g. `~/.nvm/.../lib/`) instead of the user's home directory. Skills linked there are invisible to agent systems like Claude, Cursor, etc.

Now passes `homedir()` as `wireTarget` so `skills add`, `add-mcp`, `add-agent`, and `add-prompt` all run with `cwd=$HOME` for global installs.

**Tests:** 2 new tests verifying `wireTarget` is used correctly (30 total).