### PR TITLE
chore: release v0.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillpm",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Package manager for Agent Skills. Built on npm.",
   "type": "module",
   "bin": {

--- a/packages/skillpm-skill/package.json
+++ b/packages/skillpm-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillpm-skill",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Agent Skill for managing skills with skillpm — install, publish, and wire Agent Skills into AI agent directories",
   "keywords": [
     "agent-skill",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import { sync } from './commands/sync.js';
 import { mcp } from './commands/mcp.js';
 import { log } from './utils/index.js';
 
-const VERSION = '0.0.1';
+const VERSION = '0.0.2';
 
 const HELP = `
 skillpm — Agent Skill package manager


### PR DESCRIPTION
Bump version to 0.0.2 for patch release.

**Changes since v0.0.1:**
- feat: wire agents and prompts from skill packages (#21)
- fix: scan global node_modules for -g installs (#22)
- fix: wire global skills into home directory, not npm prefix (#23)
- fix: update legacy warning URL to skillpm.dev (#20)
- docs: deduplicate homepage and docs (#18, #19)