### PR TITLE
fix: add NODE_AUTH_TOKEN to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,13 @@ jobs:
 
       - name: Publish skillpm to npm
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish skillpm-skill to npm
         run: npm publish -w packages/skillpm-skill --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
The release workflow was missing the `NODE_AUTH_TOKEN` env var on publish steps, causing npm publish to fail with 404.