### PR TITLE
chore: release v0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillpm",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Package manager for Agent Skills. Built on npm.",
   "type": "module",
   "bin": {

--- a/packages/skillpm-skill/package.json
+++ b/packages/skillpm-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillpm-skill",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Agent Skill for managing skills with skillpm — install, publish, and wire Agent Skills into AI agent directories",
   "keywords": [
     "agent-skill",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import { sync } from './commands/sync.js';
 import { mcp } from './commands/mcp.js';
 import { log } from './utils/index.js';
 
-const VERSION = '0.0.2';
+const VERSION = '0.0.3';
 
 const HELP = `
 skillpm — Agent Skill package manager


### PR DESCRIPTION
Bump version to 0.0.3 in package.json, packages/skillpm-skill/package.json, and src/cli.ts.

After merge, tag with `v0.0.3` to trigger the release workflow (now using OIDC trusted publishing).