### PR TITLE
fix: use Node 24 in release workflow for OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: latest
           cache: npm
           registry-url: https://registry.npmjs.org
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skillpm",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skillpm",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/node": "^25.3.0",
+        "@types/node": "^25.3.1",
         "eslint": "^10.0.2",
         "prettier": "^3.8.1",
         "typescript": "^5.9.3",
@@ -1058,9 +1058,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
-      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "version": "25.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.1.tgz",
+      "integrity": "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2793,7 +2793,7 @@
       }
     },
     "packages/skillpm-skill": {
-      "version": "0.0.1",
+      "version": "0.0.3",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/node": "^25.3.0",
+    "@types/node": "^25.3.1",
     "eslint": "^10.0.2",
     "prettier": "^3.8.1",
     "typescript": "^5.9.3",


### PR DESCRIPTION
OIDC trusted publishing (tokenless) requires npm 11.5.1+. Node 22 ships with npm 10.x which doesn't support it — causing the v0.0.3 release to fail with 'Access token expired or revoked'.

Node 24 ships with npm 11.x, matching the working setup in mcp-server-excel.