### PR TITLE
feat: configPrefix support, scope stripping, and single-dash separator for configs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -129,7 +129,7 @@ When a user runs `skillpm install refactor-react`:
 3. For each skill found, skillpm calls `npx skills add ./node_modules/<package>/skills/<name>/` to link it into agent directories
 4. skillpm reads the `skillpm` field from each installed skill's `package.json` (transitive walk):
    - `skillpm.mcpServers[]` → shells out to `npx add-mcp <source>` for each
-5. For each skill with a `configs/` directory, skillpm copies files to the workspace root with package-name prefixed filenames (tracked in `.skillpm/manifest.json`)
+5. For each skill with a `configs/` directory, skillpm copies files to the workspace root with auto-prefixed filenames (de-scoped package name, or `skillpm.configPrefix` if set) tracked in `.skillpm/manifest.json`
 6. Done — agents see the full skill tree with MCP servers configured
 
 ### Core CLI commands
@@ -203,6 +203,19 @@ npm run lint          # lint
 - Use **zod** for validating the `skillpm` field schema in `package.json`.
 - Use **gray-matter** for parsing YAML frontmatter from SKILL.md files.
 - Prefer explicit, actionable error messages — this is a CLI tool, not a library.
+
+### Examples and naming in docs, issues, and comments
+
+**Always use generic placeholder names** in all documentation, GitHub issues, PR descriptions, code comments, and test fixtures. Never use real project names, internal org names, or private package names from any specific user's environment.
+
+| Context | Use this | Never use |
+|---------|----------|-----------|
+| Scoped package name | `@org/my-skill`, `@acme/fullstack-react` | `@mcaps/spt-iq-consumption`, `@microsoft/internal-skill` |
+| Config prefix | `react`, `my-skill` | `spt-iq-consumption`, `consumption` |
+| Org / registry | `my-org`, `acme` | `mcaps`, `stbrnner`, any real org name |
+| Skill name | `my-skill`, `pdf-processing`, `refactor-react` | Any real customer or internal project name |
+
+This applies everywhere: inline code, tables, shell examples, test case descriptions, and issue bodies.
 
 ## Git workflow
 

--- a/docs/creating-skills.md
+++ b/docs/creating-skills.md
@@ -119,15 +119,35 @@ my-skill/
 
 ### How it works
 
-On `skillpm install`, files from `configs/` are copied to the workspace root with an auto-prefix to prevent conflicts between skills:
+On `skillpm install`, files from `configs/` are copied to the workspace root with an auto-prefix to prevent conflicts between skills.
+
+The prefix is determined in this order:
+
+1. **`skillpm.configPrefix`** in `package.json` — explicit short name (e.g. `react`)
+2. **De-scoped package name** — `@scope/` is stripped automatically (e.g. `@acme/fullstack-react` → `fullstack-react`)
 
 | Source | Destination |
 |--------|-------------|
-| `configs/.claude/agents/reviewer.md` | `.claude/agents/my-skill--reviewer.md` |
-| `configs/.cursor/rules/conventions.md` | `.cursor/rules/my-skill--conventions.md` |
-| `configs/.github/instructions/help.instructions.md` | `.github/instructions/my-skill--help.instructions.md` |
+| `configs/.claude/agents/reviewer.md` | `.claude/agents/my-skill-reviewer.md` |
+| `configs/.cursor/rules/conventions.md` | `.cursor/rules/my-skill-conventions.md` |
+| `configs/.github/instructions/help.instructions.md` | `.github/instructions/my-skill-help.instructions.md` |
 
 On `skillpm uninstall`, all copied files are removed automatically using the manifest at `.skillpm/manifest.json`.
+
+### Shortening the prefix with `configPrefix`
+
+For scoped packages or packages with long names, set `configPrefix` in the `skillpm` field to use a shorter prefix:
+
+```json
+{
+  "name": "@acme/fullstack-react",
+  "skillpm": {
+    "configPrefix": "react"
+  }
+}
+```
+
+This gives `react-reviewer.md` instead of `fullstack-react-reviewer.md`.
 
 ### Supported targets
 
@@ -172,6 +192,13 @@ If your skill requires MCP servers, declare them in the `skillpm` field:
   }
 }
 ```
+
+The `skillpm` field supports these options:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mcpServers` | `string[]` | MCP servers to configure via `add-mcp` on install |
+| `configPrefix` | `string` | Override the prefix used for deployed `configs/` filenames. Defaults to the de-scoped package name. |
 
 skillpm collects MCP server requirements from the entire dependency tree (transitively, deduplicated) and configures them via [`add-mcp`](https://github.com/neondatabase/add-mcp).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skillpm",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skillpm",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -2793,7 +2793,7 @@
       }
     },
     "packages/skillpm-skill": {
-      "version": "0.0.3",
+      "version": "0.0.5",
       "license": "MIT"
     }
   }

--- a/packages/skillpm-skill/skills/skillpm/SKILL.md
+++ b/packages/skillpm-skill/skills/skillpm/SKILL.md
@@ -24,7 +24,7 @@ Use this skill when the user wants to:
 - **One skill per npm package.** The skill lives in `skills/<name>/SKILL.md` inside the package.
 - **Transitive dependency resolution.** skillpm walks the full dependency tree to discover all skills and MCP server requirements.
 - **Agent directory wiring.** skillpm uses the `skills` CLI to link installed skills into 37+ agent directories (Claude, Cursor, VS Code, Codex, Gemini CLI, etc.).
-- **Config files.** Skills can include a `configs/` directory to ship native agent config files (subagent definitions, rules, prompts). The directory mirrors the workspace layout — files are copied on install with package-name prefixes to prevent conflicts.
+- **Config files.** Skills can include a `configs/` directory to ship native agent config files (subagent definitions, rules, prompts). The directory mirrors the workspace layout — files are copied on install with an auto-prefix (de-scoped package name, or a shorter `skillpm.configPrefix` override) to prevent conflicts.
 - **MCP server configuration.** Skills can declare MCP servers in `package.json` under `skillpm.mcpServers[]`. skillpm configures them via `add-mcp`.
 
 ## Commands
@@ -149,7 +149,9 @@ my-skill/
 
 ### Bundling agent configs, rules, and prompts
 
-`SKILL.md` teaches agents *what to do* — instructions read at runtime. The `configs/` directory lets you also ship **config files** (subagent definitions, rules, instructions) in the native format of each agent system. It mirrors the workspace layout — files get copied to the workspace root on install, auto-prefixed with the package name to avoid conflicts.
+`SKILL.md` teaches agents *what to do* — instructions read at runtime. The `configs/` directory lets you also ship **config files** (subagent definitions, rules, instructions) in the native format of each agent system. It mirrors the workspace layout — files get copied to the workspace root on install, auto-prefixed to avoid conflicts.
+
+The prefix used is: `configPrefix` (if set in `skillpm` field) → de-scoped package name (e.g. `@acme/fullstack-react` → `fullstack-react`). Set `configPrefix` to a short name when the package name is long.
 
 Each agent system uses different names and directories:
 
@@ -165,9 +167,9 @@ To ship config files, create a `configs/` directory that mirrors the workspace l
 
 | Source in package | Destination in workspace |
 |---|---|
-| `configs/.claude/agents/reviewer.md` | `.claude/agents/my-skill--reviewer.md` |
-| `configs/.cursor/rules/conventions.md` | `.cursor/rules/my-skill--conventions.md` |
-| `configs/.github/instructions/help.instructions.md` | `.github/instructions/my-skill--help.instructions.md` |
+| `configs/.claude/agents/reviewer.md` | `.claude/agents/my-skill-reviewer.md` |
+| `configs/.cursor/rules/conventions.md` | `.cursor/rules/my-skill-conventions.md` |
+| `configs/.github/instructions/help.instructions.md` | `.github/instructions/my-skill-help.instructions.md` |
 
 On uninstall, all copied files are removed automatically (tracked via `.skillpm/manifest.json`).
 

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -78,10 +78,10 @@ describe('wireSkills', () => {
     });
     await wireSkills(cwd);
 
-    const reviewer = await readFile(join(cwd, '.claude/agents/my-skill--reviewer.md'), 'utf-8');
+    const reviewer = await readFile(join(cwd, '.claude/agents/my-skill-reviewer.md'), 'utf-8');
     expect(reviewer).toBe('# Reviewer agent');
 
-    const conventions = await readFile(join(cwd, '.cursor/rules/my-skill--conventions.md'), 'utf-8');
+    const conventions = await readFile(join(cwd, '.cursor/rules/my-skill-conventions.md'), 'utf-8');
     expect(conventions).toBe('# Conventions');
   });
 
@@ -92,7 +92,7 @@ describe('wireSkills', () => {
     await wireSkills(cwd);
 
     const manifest = JSON.parse(await readFile(join(cwd, '.skillpm/manifest.json'), 'utf-8'));
-    expect(manifest['my-skill']).toEqual(['.claude/agents/my-skill--reviewer.md']);
+    expect(manifest['my-skill']).toEqual(['.claude/agents/my-skill-reviewer.md']);
   });
 
   it('skips configs for skills without configs/ directory', async () => {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -76,7 +76,7 @@ export async function wireSkills(cwd: string): Promise<void> {
     if (skill.configsDir) {
       log.info(`Copying config files from ${log.skill(skill.name, skill.version)}`);
       try {
-        const copied = await copyConfigs(skill.configsDir, cwd, skill.name);
+        const copied = await copyConfigs(skill.configsDir, cwd, skill.name, skill.configPrefix);
         log.success(`Copied ${copied.length} config file(s) from ${skill.name}`);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/src/commands/publish.test.ts
+++ b/src/commands/publish.test.ts
@@ -47,7 +47,7 @@ describe('validatePublish', () => {
     const errors = await validatePublish(dir);
     expect(errors).toEqual([]);
     expect(mockNpx).toHaveBeenCalledWith(
-      ['skills-ref', 'validate', expect.stringContaining('skills/test-skill')],
+      ['skills-ref', 'validate', expect.stringContaining(join('skills', 'test-skill'))],
     );
     await rm(dir, { recursive: true, force: true });
   });

--- a/src/configs/index.test.ts
+++ b/src/configs/index.test.ts
@@ -23,8 +23,8 @@ describe('copyConfigs', () => {
 
     const copied = await copyConfigs(configsDir, cwd, 'my-skill');
 
-    expect(copied).toEqual(['.claude/agents/my-skill--reviewer.md']);
-    const content = await readFile(join(cwd, '.claude', 'agents', 'my-skill--reviewer.md'), 'utf-8');
+    expect(copied).toEqual(['.claude/agents/my-skill-reviewer.md']);
+    const content = await readFile(join(cwd, '.claude', 'agents', 'my-skill-reviewer.md'), 'utf-8');
     expect(content).toBe('# Reviewer');
   });
 
@@ -39,9 +39,9 @@ describe('copyConfigs', () => {
     const copied = await copyConfigs(configsDir, cwd, 'pkg');
 
     expect(copied).toHaveLength(3);
-    expect(copied).toContain('.claude/agents/pkg--bot.md');
-    expect(copied).toContain('.cursor/rules/pkg--style.md');
-    expect(copied).toContain('.github/instructions/pkg--help.instructions.md');
+    expect(copied).toContain('.claude/agents/pkg-bot.md');
+    expect(copied).toContain('.cursor/rules/pkg-style.md');
+    expect(copied).toContain('.github/instructions/pkg-help.instructions.md');
   });
 
   it('writes manifest with copied files', async () => {
@@ -51,7 +51,7 @@ describe('copyConfigs', () => {
     await copyConfigs(configsDir, cwd, 'test-pkg');
 
     const manifest = JSON.parse(await readFile(join(cwd, '.skillpm', 'manifest.json'), 'utf-8'));
-    expect(manifest['test-pkg']).toEqual(['.claude/agents/test-pkg--a.md']);
+    expect(manifest['test-pkg']).toEqual(['.claude/agents/test-pkg-a.md']);
   });
 
   it('updates manifest for multiple packages', async () => {
@@ -66,8 +66,8 @@ describe('copyConfigs', () => {
     await copyConfigs(configs2, cwd, 'pkg-b');
 
     const manifest = JSON.parse(await readFile(join(cwd, '.skillpm', 'manifest.json'), 'utf-8'));
-    expect(manifest['pkg-a']).toEqual(['.claude/agents/pkg-a--a.md']);
-    expect(manifest['pkg-b']).toEqual(['.cursor/rules/pkg-b--b.md']);
+    expect(manifest['pkg-a']).toEqual(['.claude/agents/pkg-a-a.md']);
+    expect(manifest['pkg-b']).toEqual(['.cursor/rules/pkg-b-b.md']);
   });
 
   it('returns empty array for empty configs dir', async () => {
@@ -76,15 +76,48 @@ describe('copyConfigs', () => {
     expect(copied).toEqual([]);
   });
 
-  it('handles scoped package names in prefix', async () => {
+  it('strips npm scope from package name prefix', async () => {
     await mkdir(join(configsDir, '.claude', 'agents'), { recursive: true });
     await writeFile(join(configsDir, '.claude', 'agents', 'bot.md'), 'agent');
 
     const copied = await copyConfigs(configsDir, cwd, '@org/my-skill');
 
-    expect(copied).toEqual(['.claude/agents/@org/my-skill--bot.md']);
-    const content = await readFile(join(cwd, '.claude', 'agents', '@org/my-skill--bot.md'), 'utf-8');
+    // Scope is stripped: prefix is "my-skill", not "@org/my-skill"
+    expect(copied).toEqual(['.claude/agents/my-skill-bot.md']);
+    const content = await readFile(join(cwd, '.claude', 'agents', 'my-skill-bot.md'), 'utf-8');
     expect(content).toBe('agent');
+  });
+
+  it('uses configPrefix instead of package name when provided', async () => {
+    await mkdir(join(configsDir, '.claude', 'commands', 'spt-iq'), { recursive: true });
+    await writeFile(join(configsDir, '.claude', 'commands', 'spt-iq', 'briefing.md'), '# Briefing');
+
+    const copied = await copyConfigs(configsDir, cwd, '@mcaps/spt-iq-consumption', 'consumption');
+
+    expect(copied).toEqual(['.claude/commands/spt-iq/consumption-briefing.md']);
+    const content = await readFile(
+      join(cwd, '.claude', 'commands', 'spt-iq', 'consumption-briefing.md'),
+      'utf-8',
+    );
+    expect(content).toBe('# Briefing');
+  });
+
+  it('configPrefix overrides scope-stripped name', async () => {
+    await mkdir(join(configsDir, '.github', 'agents'), { recursive: true });
+    await writeFile(join(configsDir, '.github', 'agents', 'agent.md'), '# Agent');
+
+    // Without configPrefix: scope stripped → "spt-iq-consumption-agent.md"
+    const without = await copyConfigs(configsDir, cwd, '@mcaps/spt-iq-consumption');
+    expect(without).toEqual(['.github/agents/spt-iq-consumption-agent.md']);
+
+    // Cleanup
+    await rm(join(cwd, '.github'), { recursive: true, force: true });
+    await mkdir(join(configsDir, '.github', 'agents'), { recursive: true });
+    await writeFile(join(configsDir, '.github', 'agents', 'agent.md'), '# Agent');
+
+    // With configPrefix: → "consumption-agent.md"
+    const withPrefix = await copyConfigs(configsDir, cwd, '@mcaps/spt-iq-consumption', 'consumption');
+    expect(withPrefix).toEqual(['.github/agents/consumption-agent.md']);
   });
 });
 
@@ -102,17 +135,17 @@ describe('removeConfigs', () => {
   it('removes files listed in manifest', async () => {
     // Set up wired files + manifest
     await mkdir(join(cwd, '.claude', 'agents'), { recursive: true });
-    await writeFile(join(cwd, '.claude', 'agents', 'my-skill--reviewer.md'), '# Reviewer');
+    await writeFile(join(cwd, '.claude', 'agents', 'my-skill-reviewer.md'), '# Reviewer');
     await mkdir(join(cwd, '.skillpm'), { recursive: true });
     await writeFile(
       join(cwd, '.skillpm', 'manifest.json'),
-      JSON.stringify({ 'my-skill': ['.claude/agents/my-skill--reviewer.md'] }),
+      JSON.stringify({ 'my-skill': ['.claude/agents/my-skill-reviewer.md'] }),
     );
 
     const removed = await removeConfigs(cwd, 'my-skill');
 
-    expect(removed).toEqual(['.claude/agents/my-skill--reviewer.md']);
-    await expect(access(join(cwd, '.claude', 'agents', 'my-skill--reviewer.md'))).rejects.toThrow();
+    expect(removed).toEqual(['.claude/agents/my-skill-reviewer.md']);
+    await expect(access(join(cwd, '.claude', 'agents', 'my-skill-reviewer.md'))).rejects.toThrow();
   });
 
   it('removes package entry from manifest', async () => {
@@ -120,13 +153,13 @@ describe('removeConfigs', () => {
     await writeFile(
       join(cwd, '.skillpm', 'manifest.json'),
       JSON.stringify({
-        'pkg-a': ['.claude/agents/pkg-a--a.md'],
-        'pkg-b': ['.cursor/rules/pkg-b--b.md'],
+        'pkg-a': ['.claude/agents/pkg-a-a.md'],
+        'pkg-b': ['.cursor/rules/pkg-b-b.md'],
       }),
     );
     // Create files
     await mkdir(join(cwd, '.claude', 'agents'), { recursive: true });
-    await writeFile(join(cwd, '.claude', 'agents', 'pkg-a--a.md'), 'a');
+    await writeFile(join(cwd, '.claude', 'agents', 'pkg-a-a.md'), 'a');
 
     await removeConfigs(cwd, 'pkg-a');
 
@@ -144,7 +177,7 @@ describe('removeConfigs', () => {
     await mkdir(join(cwd, '.skillpm'), { recursive: true });
     await writeFile(
       join(cwd, '.skillpm', 'manifest.json'),
-      JSON.stringify({ 'ghost': ['.claude/agents/ghost--a.md'] }),
+      JSON.stringify({ 'ghost': ['.claude/agents/ghost-a.md'] }),
     );
 
     // File doesn't exist — should not throw
@@ -173,14 +206,14 @@ describe('copyConfigs + removeConfigs roundtrip', () => {
 
     await copyConfigs(configsDir, cwd, 'my-skill');
     // Verify files exist
-    await expect(readFile(join(cwd, '.claude', 'agents', 'my-skill--bot.md'), 'utf-8')).resolves.toBe('agent');
+    await expect(readFile(join(cwd, '.claude', 'agents', 'my-skill-bot.md'), 'utf-8')).resolves.toBe('agent');
 
     const removed = await removeConfigs(cwd, 'my-skill');
     expect(removed).toHaveLength(2);
 
     // Verify files are gone
-    await expect(access(join(cwd, '.claude', 'agents', 'my-skill--bot.md'))).rejects.toThrow();
-    await expect(access(join(cwd, '.cursor', 'rules', 'my-skill--style.md'))).rejects.toThrow();
+    await expect(access(join(cwd, '.claude', 'agents', 'my-skill-bot.md'))).rejects.toThrow();
+    await expect(access(join(cwd, '.cursor', 'rules', 'my-skill-style.md'))).rejects.toThrow();
 
     // Manifest should have empty entry for my-skill
     const manifest = JSON.parse(await readFile(join(cwd, '.skillpm', 'manifest.json'), 'utf-8'));

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -4,6 +4,11 @@ import { join, relative, dirname, basename } from 'node:path';
 const MANIFEST_DIR = '.skillpm';
 const MANIFEST_FILE = 'manifest.json';
 
+/** Normalize path separators to forward slashes for cross-platform consistency. */
+function normalizePath(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
 interface ConfigsManifest {
   [packageName: string]: string[];
 }
@@ -41,37 +46,64 @@ async function walkDir(dir: string, root?: string): Promise<string[]> {
     if (s.isDirectory()) {
       files.push(...(await walkDir(full, root)));
     } else {
-      files.push(relative(root, full));
+      files.push(normalizePath(relative(root, full)));
     }
   }
   return files;
 }
 
 /**
- * Auto-prefix a filename with the package name to avoid conflicts.
- * e.g. "reviewer.md" with package "my-skill" → "my-skill--reviewer.md"
+ * Strip npm scope from a package name.
+ * e.g. "@mcaps/spt-iq-consumption" → "spt-iq-consumption"
+ *      "spt-iq-consumption"       → "spt-iq-consumption"
  */
-function prefixFilename(relPath: string, packageName: string): string {
+function stripScope(packageName: string): string {
+  if (packageName.startsWith('@')) {
+    const slash = packageName.indexOf('/');
+    return slash >= 0 ? packageName.slice(slash + 1) : packageName;
+  }
+  return packageName;
+}
+
+/**
+ * Auto-prefix a filename with the resolved prefix to avoid conflicts.
+ * e.g. "reviewer.md" with prefix "my-skill" → "my-skill-reviewer.md"
+ */
+function prefixFilename(relPath: string, prefix: string): string {
   const dir = dirname(relPath);
   const file = basename(relPath);
-  const prefixed = `${packageName}--${file}`;
-  return dir === '.' ? prefixed : join(dir, prefixed);
+  const prefixed = `${prefix}-${file}`;
+  return normalizePath(dir === '.' ? prefixed : join(dir, prefixed));
 }
 
 /**
  * Copy all files from a skill's configs/ directory to the workspace,
- * auto-prefixing filenames with the package name.
+ * auto-prefixing filenames to avoid conflicts between installed skills.
+ *
+ * The prefix used is, in priority order:
+ *   1. `configPrefix` argument (from skillpm.configPrefix in package.json)
+ *   2. De-scoped package name (strips "@scope/" from scoped packages)
+ *
+ * Examples:
+ *   packageName="@mcaps/spt-iq-consumption", configPrefix="consumption"
+ *     → "consumption-briefing.md"
+ *   packageName="@mcaps/spt-iq-consumption", no configPrefix
+ *     → "spt-iq-consumption-briefing.md"
+ *   packageName="my-skill", no configPrefix
+ *     → "my-skill-briefing.md"
  */
 export async function copyConfigs(
   configsDir: string,
   cwd: string,
   packageName: string,
+  configPrefix?: string,
 ): Promise<string[]> {
+  const prefix = configPrefix ?? stripScope(packageName);
   const files = await walkDir(configsDir);
   const copied: string[] = [];
 
   for (const relPath of files) {
-    const prefixed = prefixFilename(relPath, packageName);
+    const prefixed = prefixFilename(relPath, prefix);
     const src = join(configsDir, relPath);
     const dest = join(cwd, prefixed);
     await mkdir(dirname(dest), { recursive: true });

--- a/src/manifest/schema.ts
+++ b/src/manifest/schema.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const SkillpmFieldSchema = z
   .object({
     mcpServers: z.array(z.string()).optional(),
+    configPrefix: z.string().optional(),
   })
   .strict()
   .optional();
@@ -28,4 +29,11 @@ export interface SkillInfo {
   legacy?: boolean;
   /** Path to configs/ directory if present (mirrors workspace layout) */
   configsDir?: string;
+  /**
+   * Optional prefix override for config file naming.
+   * When set, used instead of the (de-scoped) package name.
+   * e.g. configPrefix: "consumption" → "consumption--briefing.md"
+   * Declared via skillpm.configPrefix in package.json.
+   */
+  configPrefix?: string;
 }

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -87,6 +87,7 @@ async function tryReadSkill(pkgDir: string): Promise<SkillInfo | null> {
       skillDir,
       mcpServers: skillpm?.mcpServers ?? [],
       configsDir: hasConfigs ? configsDir : undefined,
+      configPrefix: skillpm?.configPrefix,
     };
   }
 
@@ -106,6 +107,7 @@ async function tryReadSkill(pkgDir: string): Promise<SkillInfo | null> {
     mcpServers: skillpm?.mcpServers ?? [],
     legacy: true,
     configsDir: hasConfigs ? configsDir : undefined,
+    configPrefix: skillpm?.configPrefix,
   };
 }
 


### PR DESCRIPTION
## Summary

Resolves #35

### Changes

**\skillpm.configPrefix\ field**
- New optional field in the \skillpm\ section of \package.json\ that overrides the auto-generated config file prefix
- Allows scoped packages like \@org/my-skill\ to use a short prefix like \my-skill\ instead of the full de-scoped name

**Scope stripping**
- \@org/package-name\ now correctly strips the scope before using the package name as a prefix
- Previously, scoped packages would create nested directories like \.github/agents/@org/my-skill-reviewer.md\

**Single-dash separator**
- Config filenames now use \-\ as separator instead of \--\
- Example: \my-skill-reviewer.md\ instead of \my-skill--reviewer.md\

**Cross-platform path normalization**
- Added \
ormalizePath()\ to ensure manifest paths use forward slashes on all platforms

### Documentation
- Updated \docs/creating-skills.md\ with configPrefix usage, priority list, and examples
- Updated \packages/skillpm-skill/skills/skillpm/SKILL.md\ with updated separator and configPrefix description
- Added naming convention rule to \.github/copilot-instructions.md\

### Tests
- All 44 tests passing
- Added 3 new tests for scope stripping, configPrefix override, and precedence behavior