### PR TITLE
feat: detect npm workspace symlinks; sync workspace package configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,29 @@ skillpm doesn't reinvent anything. It orchestrates three battle-tested tools: np
 
 Aliases: `i` for `install`, `rm`/`remove` for `uninstall`, `ls` for `list`.
 
+## Monorepo / npm workspace support
+
+If your repo is an **npm workspace monorepo** where each skill is a first-party package (e.g. `skills/<name>/` entries in the root `package.json` workspaces field), npm installs them as symlinks inside `node_modules/`:
+
+```
+node_modules/
+  @org/
+    my-skill → ../../skills/my-skill   ← symlink
+```
+
+`skillpm sync` (and `skillpm install`) automatically detects these symlinks and treats them as workspace packages:
+
+- Configs are copied from the symlinked skill's `configs/` directory into the workspace root, exactly as for externally installed skills.
+- Workspace packages are identified in log output: `Linking workspace package @org/my-skill@1.0.0`.
+
+This lets contributors regenerate deployed copies (agent definitions, prompts, rules) by running:
+
+```bash
+skillpm sync
+```
+
+No manual copy steps needed. Commit the regenerated files as usual.
+
 ## Creating a skill
 
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -91,6 +91,29 @@ skillpm sync
 
 Useful after manual changes to `node_modules/` or when agent directories need refreshing.
 
+### Monorepo / npm workspace support
+
+When your repo uses **npm workspaces**, npm creates symlinks inside `node_modules/` that point to your first-party skill packages:
+
+```
+node_modules/
+  @org/
+    my-skill → ../../skills/my-skill   ← npm workspace symlink
+```
+
+`skillpm sync` detects these symlinks automatically. Each symlinked package is treated as a **workspace package** — its `configs/` directory is copied into the workspace root, regenerating all deployed agent definitions, prompts, and rules. Workspace packages are tagged in output:
+
+```
+ℹ Linking workspace package @org/my-skill@1.0.0 into agent directories
+ℹ Copying config files from workspace package @org/my-skill@1.0.0
+```
+
+**Contributor workflow for in-repo skill monorepos:**
+
+1. Edit source files in `skills/<name>/configs/`
+2. Run `skillpm sync` to regenerate deployed copies
+3. Commit the regenerated files
+
 ---
 
 ## `skillpm mcp add <source...>`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skillpm",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skillpm",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillpm",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Package manager for Agent Skills. Built on npm.",
   "type": "module",
   "bin": {

--- a/packages/skillpm-skill/skills/skillpm/SKILL.md
+++ b/packages/skillpm-skill/skills/skillpm/SKILL.md
@@ -88,6 +88,16 @@ npx skillpm sync
 
 Re-scans `node_modules/` and re-links all skills into agent directories without reinstalling. Useful after manual changes.
 
+**Monorepo / npm workspace support:** If your repo uses npm workspaces, npm creates symlinks in `node_modules/` pointing to your first-party skill packages. `skillpm sync` detects these symlinks and copies their `configs/` files into the workspace root — same as for externally installed skills. Contributors run `skillpm sync` after editing a skill's source files, then commit the regenerated configs.
+
+```
+node_modules/
+  @org/
+    my-skill → ../../skills/my-skill   ← symlink (npm workspace)
+```
+
+Workspace packages appear in sync output as: `Linking workspace package @org/my-skill@1.0.0`.
+
 ### Configure MCP servers
 
 ```bash

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import { sync } from './commands/sync.js';
 import { mcp } from './commands/mcp.js';
 import { log } from './utils/index.js';
 
-const VERSION = '0.0.4';
+const VERSION = '0.0.7';
 
 const HELP = `
 skillpm — Agent Skill package manager

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, writeFile, mkdir, rm, readFile } from 'node:fs/promises';
+import { mkdtemp, writeFile, mkdir, rm, readFile, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -107,5 +107,65 @@ describe('wireSkills', () => {
       // No manifest file created — expected
     }
     expect(manifest).not.toHaveProperty('plain-skill');
+  });
+
+  it('copies config files from a workspace symlinked package', async () => {
+    // Real package lives outside node_modules/ — simulates npm workspace symlink
+    const realPkgDir = join(cwd, 'skills', 'workspace-skill');
+    const skillDir = join(realPkgDir, 'skills', 'workspace-skill');
+    const configsDir = join(realPkgDir, 'configs');
+    await mkdir(skillDir, { recursive: true });
+    await mkdir(join(configsDir, '.github', 'agents'), { recursive: true });
+    await writeFile(
+      join(realPkgDir, 'package.json'),
+      JSON.stringify({ name: 'workspace-skill', version: '1.0.0' }),
+    );
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: workspace-skill\ndescription: Test\n---\n',
+    );
+    await writeFile(join(configsDir, '.github', 'agents', 'agent.md'), '# Workspace Agent');
+
+    // Create symlink in node_modules/ (like npm workspaces does)
+    const nodeModulesDir = join(cwd, 'node_modules');
+    await mkdir(nodeModulesDir, { recursive: true });
+    await symlink(realPkgDir, join(nodeModulesDir, 'workspace-skill'), 'junction');
+
+    await wireSkills(cwd);
+
+    const content = await readFile(join(cwd, '.github', 'agents', 'workspace-skill-agent.md'), 'utf-8');
+    expect(content).toBe('# Workspace Agent');
+
+    const manifest = JSON.parse(await readFile(join(cwd, '.skillpm', 'manifest.json'), 'utf-8'));
+    expect(manifest['workspace-skill']).toEqual(['.github/agents/workspace-skill-agent.md']);
+  });
+
+  it('handles a mix of workspace and regular skill packages', async () => {
+    // Regular published skill
+    await setupSkillPackage(join(cwd, 'node_modules'), 'published-skill', {
+      configs: { '.claude/agents/bot.md': '# Published bot' },
+    });
+
+    // Workspace skill via symlink
+    const realPkgDir = join(cwd, 'skills', 'local-skill');
+    const skillDir = join(realPkgDir, 'skills', 'local-skill');
+    const configsDir = join(realPkgDir, 'configs');
+    await mkdir(skillDir, { recursive: true });
+    await mkdir(join(configsDir, '.claude', 'agents'), { recursive: true });
+    await writeFile(
+      join(realPkgDir, 'package.json'),
+      JSON.stringify({ name: 'local-skill', version: '1.0.0' }),
+    );
+    await writeFile(join(skillDir, 'SKILL.md'), '---\nname: local-skill\n---\n');
+    await writeFile(join(configsDir, '.claude', 'agents', 'local.md'), '# Local bot');
+    await symlink(realPkgDir, join(cwd, 'node_modules', 'local-skill'), 'junction');
+
+    await wireSkills(cwd);
+
+    const published = await readFile(join(cwd, '.claude', 'agents', 'published-skill-bot.md'), 'utf-8');
+    expect(published).toBe('# Published bot');
+
+    const local = await readFile(join(cwd, '.claude', 'agents', 'local-skill-local.md'), 'utf-8');
+    expect(local).toBe('# Local bot');
   });
 });

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -40,7 +40,8 @@ export async function wireSkills(cwd: string): Promise<void> {
 
   // Wire each skill into agent directories via skills CLI
   for (const skill of skills) {
-    log.info(`Linking ${log.skill(skill.name, skill.version)} into agent directories`);
+    const label = skill.workspace ? `workspace package ${log.skill(skill.name, skill.version)}` : log.skill(skill.name, skill.version);
+    log.info(`Linking ${label} into agent directories`);
     try {
       await npx(['skills', 'add', skill.skillDir, '--all', '-y'], { cwd });
       log.success(`Linked ${skill.name}`);
@@ -74,7 +75,8 @@ export async function wireSkills(cwd: string): Promise<void> {
   // Copy configs/ files (agents, prompts, rules) into workspace
   for (const skill of skills) {
     if (skill.configsDir) {
-      log.info(`Copying config files from ${log.skill(skill.name, skill.version)}`);
+      const label = skill.workspace ? `workspace package ${log.skill(skill.name, skill.version)}` : log.skill(skill.name, skill.version);
+      log.info(`Copying config files from ${label}`);
       try {
         const copied = await copyConfigs(skill.configsDir, cwd, skill.name, skill.configPrefix);
         log.success(`Copied ${copied.length} config file(s) from ${skill.name}`);

--- a/src/manifest/schema.ts
+++ b/src/manifest/schema.ts
@@ -36,4 +36,9 @@ export interface SkillInfo {
    * Declared via skillpm.configPrefix in package.json.
    */
   configPrefix?: string;
+  /**
+   * True when the package was found via a symlink in node_modules/ — typically
+   * an npm workspace package (first-party skill in the same monorepo).
+   */
+  workspace?: boolean;
 }

--- a/src/scanner/index.test.ts
+++ b/src/scanner/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, rm, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { scanNodeModules, collectMcpServers } from './index.js';
@@ -168,5 +168,100 @@ describe('configs/ directory scanning', () => {
     const result = await scanNodeModules(tmpDir);
     expect(result).toHaveLength(1);
     expect(result[0].configsDir).toBeUndefined();
+  });
+});
+
+describe('workspace package (symlink) detection', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'skillpm-workspace-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('sets workspace: true for a symlinked (workspace) skill package', async () => {
+    // Simulate an npm workspace: real package lives outside node_modules,
+    // node_modules/<name> is a symlink pointing to it.
+    const realPkgDir = join(tmpDir, 'skills', 'my-skill');
+    const skillDir = join(realPkgDir, 'skills', 'my-skill');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(realPkgDir, 'package.json'),
+      JSON.stringify({ name: 'my-skill', version: '1.0.0' }),
+    );
+    await writeFile(join(skillDir, 'SKILL.md'), '---\nname: my-skill\ndescription: Test\n---\n');
+
+    const nodeModulesDir = join(tmpDir, 'node_modules');
+    await mkdir(nodeModulesDir, { recursive: true });
+    await symlink(realPkgDir, join(nodeModulesDir, 'my-skill'), 'junction');
+
+    const result = await scanNodeModules(tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('my-skill');
+    expect(result[0].workspace).toBe(true);
+  });
+
+  it('does NOT set workspace: true for a regular (non-symlinked) package', async () => {
+    const pkgDir = join(tmpDir, 'node_modules', 'regular-skill');
+    const skillDir = join(pkgDir, 'skills', 'regular-skill');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ name: 'regular-skill', version: '1.0.0' }),
+    );
+    await writeFile(join(skillDir, 'SKILL.md'), '---\nname: regular-skill\n---\n');
+
+    const result = await scanNodeModules(tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].workspace).toBeUndefined();
+  });
+
+  it('sets workspace: true for a scoped symlinked package', async () => {
+    const realPkgDir = join(tmpDir, 'skills', 'skill-a');
+    const skillDir = join(realPkgDir, 'skills', 'skill-a');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(realPkgDir, 'package.json'),
+      JSON.stringify({ name: '@org/skill-a', version: '1.0.0' }),
+    );
+    await writeFile(join(skillDir, 'SKILL.md'), '---\nname: skill-a\n---\n');
+
+    const scopeDir = join(tmpDir, 'node_modules', '@org');
+    await mkdir(scopeDir, { recursive: true });
+    await symlink(realPkgDir, join(scopeDir, 'skill-a'), 'junction');
+
+    const result = await scanNodeModules(tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('@org/skill-a');
+    expect(result[0].workspace).toBe(true);
+  });
+
+  it('syncs configs from a workspace symlinked package', async () => {
+    // Integration: symlinked skill with configs/ → configs are accessible via symlink
+    const realPkgDir = join(tmpDir, 'skills', 'wired-skill');
+    const skillDir = join(realPkgDir, 'skills', 'wired-skill');
+    const configsDir = join(realPkgDir, 'configs', '.github', 'agents');
+    await mkdir(skillDir, { recursive: true });
+    await mkdir(configsDir, { recursive: true });
+    await writeFile(
+      join(realPkgDir, 'package.json'),
+      JSON.stringify({ name: 'wired-skill', version: '1.0.0' }),
+    );
+    await writeFile(join(skillDir, 'SKILL.md'), '---\nname: wired-skill\n---\n');
+    await writeFile(join(configsDir, 'agent.md'), '# Agent');
+
+    const nodeModulesDir = join(tmpDir, 'node_modules');
+    const linkPath = join(nodeModulesDir, 'wired-skill');
+    await mkdir(nodeModulesDir, { recursive: true });
+    await symlink(realPkgDir, linkPath, 'junction');
+
+    const result = await scanNodeModules(tmpDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].workspace).toBe(true);
+    // configsDir is resolved through the symlink path (node_modules/wired-skill/configs)
+    expect(result[0].configsDir).toBe(join(linkPath, 'configs'));
   });
 });

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -1,10 +1,25 @@
-import { readdir, access } from 'node:fs/promises';
+import { readdir, access, lstat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { readPackageJson, parseSkillpmField } from '../manifest/index.js';
 import type { SkillInfo } from '../manifest/schema.js';
 
 /**
+ * Return true if the given path is a symbolic link (or on Windows, a junction).
+ * Does NOT follow the link — uses lstat so the link itself is inspected.
+ */
+async function isSymlink(p: string): Promise<boolean> {
+  try {
+    const s = await lstat(p);
+    return s.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Scan node_modules/ for packages that contain a skills/<name>/SKILL.md file.
+ * Also follows symlinks — npm workspace packages appear as symlinks inside
+ * node_modules/ and are flagged with `workspace: true` on the returned SkillInfo.
  * Returns metadata for each discovered skill package.
  */
 export async function scanNodeModules(cwd: string): Promise<SkillInfo[]> {
@@ -32,12 +47,14 @@ export async function scanNodeModules(cwd: string): Promise<SkillInfo[]> {
       }
       for (const scopedEntry of scopedEntries) {
         const pkgDir = join(scopeDir, scopedEntry);
-        const skill = await tryReadSkill(pkgDir);
+        const symlink = await isSymlink(pkgDir);
+        const skill = await tryReadSkill(pkgDir, symlink);
         if (skill) skills.push(skill);
       }
     } else {
       const pkgDir = join(nodeModulesDir, entry);
-      const skill = await tryReadSkill(pkgDir);
+      const symlink = await isSymlink(pkgDir);
+      const skill = await tryReadSkill(pkgDir, symlink);
       if (skill) skills.push(skill);
     }
   }
@@ -54,7 +71,7 @@ async function hasDir(dir: string): Promise<boolean> {
   }
 }
 
-async function tryReadSkill(pkgDir: string): Promise<SkillInfo | null> {
+async function tryReadSkill(pkgDir: string, workspace = false): Promise<SkillInfo | null> {
   const pkg = await readPackageJson(pkgDir);
   if (!pkg) return null;
 
@@ -88,6 +105,7 @@ async function tryReadSkill(pkgDir: string): Promise<SkillInfo | null> {
       mcpServers: skillpm?.mcpServers ?? [],
       configsDir: hasConfigs ? configsDir : undefined,
       configPrefix: skillpm?.configPrefix,
+      workspace: workspace || undefined,
     };
   }
 
@@ -108,6 +126,7 @@ async function tryReadSkill(pkgDir: string): Promise<SkillInfo | null> {
     legacy: true,
     configsDir: hasConfigs ? configsDir : undefined,
     configPrefix: skillpm?.configPrefix,
+    workspace: workspace || undefined,
   };
 }
 


### PR DESCRIPTION
Closes #45

## Summary

When skillpm is used in an npm workspace monorepo, npm installs first-party skill packages as symlinks inside `node_modules/`. This PR makes `skillpm sync` (and `skillpm install`) detect those symlinks and correctly sync `configs/` from workspace packages — enabling contributors to run `skillpm sync` to regenerate deployed copies without manual copy steps.

## Changes

### Core
- `SkillInfo` gains `workspace?: boolean` — set when a node_modules entry is a symlink
- `scanNodeModules` uses `lstat` (not `stat`) to detect symlinks without following them; passes `workspace` flag through `tryReadSkill`
- `wireSkills` logs workspace packages distinctly: `Linking workspace package @org/skill@1.0.0`

### Tests (50 total, all passing)
- 4 new scanner unit tests: symlink detection for unscoped, scoped, and regular packages; configs accessible via symlink
- 2 new wireSkills integration tests: workspace symlink end-to-end; mixed workspace + regular packages

### Docs
- README.md: Monorepo / npm workspace support section
- docs/commands.md: Expanded `skillpm sync` with workspace contributor workflow
- SKILL.md (skillpm-skill): workspace sync pattern documented

## Contributor workflow (after this PR)

```bash
# Edit skills/<name>/configs/ source files
skillpm sync          # regenerates .github/agents/, .claude/agents/, etc.
git add -A && git commit -m 'sync: regenerate configs'
```
