### PR TITLE
revert: undo unauthorized direct-to-main workflow and version changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -28,22 +27,10 @@ jobs:
       - run: npm test
 
       - name: Publish skillpm to npm
-        run: |
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          if npm view skillpm@$PKG_VERSION version 2>/dev/null | grep -qF "$PKG_VERSION"; then
-            echo "skillpm@$PKG_VERSION already published, skipping"
-          else
-            npm publish --provenance --access public
-          fi
+        run: npm publish --provenance --access public
 
       - name: Publish skillpm-skill to npm
-        run: |
-          PKG_VERSION=$(node -p "require('./packages/skillpm-skill/package.json').version")
-          if npm view skillpm-skill@$PKG_VERSION version 2>/dev/null | grep -qF "$PKG_VERSION"; then
-            echo "skillpm-skill@$PKG_VERSION already published, skipping"
-          else
-            npm publish -w packages/skillpm-skill --provenance --access public
-          fi
+        run: npm publish -w packages/skillpm-skill --provenance --access public
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -2793,7 +2793,7 @@
       }
     },
     "packages/skillpm-skill": {
-      "version": "0.0.7",
+      "version": "0.0.6",
       "license": "MIT"
     }
   }

--- a/packages/skillpm-skill/package.json
+++ b/packages/skillpm-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillpm-skill",
-  "version": "0.0.7",
+  "version": "0.0.6",
   "description": "Agent Skill for managing skills with skillpm — install, publish, and wire Agent Skills into AI agent directories",
   "keywords": [
     "agent-skill",


### PR DESCRIPTION
Reverts three commits that were pushed directly to main without a PR:

- chore: bump skillpm-skill to 0.0.7 (33b6606)
- chore: add workflow_dispatch to release.yml (6459f8d)
- chore: make publish steps idempotent (3a62964)

Restores release.yml to tag-push-only trigger with simple publish commands. Reverts skillpm-skill/package.json to 0.0.6.