### PR TITLE
fix: resolve spawn npx ENOENT on Windows

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -49,7 +49,7 @@ export async function wireSkills(cwd: string): Promise<void> {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(`Failed to link ${skill.name}: ${msg}`);
     }
-    if (skill.legacy) {
+    if (skill.legacy && !skill.workspace) {
       log.warn(
         `${skill.name}: SKILL.md is at package root. Move to skills/<name>/SKILL.md for full compatibility. See https://skillpm.dev/creating-skills/`,
       );

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -3,6 +3,9 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
+// On Windows, npm/npx are .cmd files and require shell resolution
+const isWindows = process.platform === 'win32';
+
 export interface ExecResult {
   stdout: string;
   stderr: string;
@@ -16,6 +19,7 @@ export async function run(
   const { stdout, stderr } = await execFileAsync(command, args, {
     cwd: opts?.cwd,
     maxBuffer: 10 * 1024 * 1024,
+    shell: isWindows,
   });
   return { stdout, stderr };
 }


### PR DESCRIPTION
## Problem

\
px skillpm sync\ fails with \spawn npx ENOENT\ on Windows because \xecFile\ does not use a shell, so \.cmd\ files (\
px.cmd\, \
pm.cmd\) are not resolved.

## Fix

- Add \shell: true\ in \xec.ts\ when \process.platform === 'win32'\
- Suppress the \SKILL.md at package root\ legacy warning for workspace packages — this layout is intentional when SKILL.md is loaded via \chat.agentSkillsLocations\

## Testing

All 50 tests pass. Verified clean sync output on Windows.