### PR TITLE
chore: release v0.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skillpm",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skillpm",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -2793,7 +2793,7 @@
       }
     },
     "packages/skillpm-skill": {
-      "version": "0.0.6",
+      "version": "0.0.8",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillpm",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Package manager for Agent Skills. Built on npm.",
   "type": "module",
   "bin": {

--- a/packages/skillpm-skill/package.json
+++ b/packages/skillpm-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillpm-skill",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "description": "Agent Skill for managing skills with skillpm — install, publish, and wire Agent Skills into AI agent directories",
   "keywords": [
     "agent-skill",


### PR DESCRIPTION
Version bump for patch release v0.0.8.

Changes in this release:
- fix: \spawn npx ENOENT\ on Windows (\shell: true\ for .cmd resolution)
- fix: suppress legacy warning for workspace packages