### PR TITLE
fix: drop --all from skills add to use agent auto-detection

### DIFF
--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -58,7 +58,7 @@ describe('wireSkills', () => {
     await rm(cwd, { recursive: true, force: true });
   });
 
-  it('calls skills add with cwd', async () => {
+  it('calls skills add with -y and cwd (no --all)', async () => {
     await setupSkillPackage(join(cwd, 'node_modules'), 'test-skill');
     await wireSkills(cwd);
 
@@ -66,6 +66,10 @@ describe('wireSkills', () => {
       (call) => call[0][0] === 'skills' && call[0][1] === 'add',
     );
     expect(skillsAddCall).toBeDefined();
+    // Must NOT pass --all — that would install to all 37+ agent directories regardless of what's installed
+    expect(skillsAddCall![0]).not.toContain('--all');
+    // Must pass -y to skip prompts
+    expect(skillsAddCall![0]).toContain('-y');
     expect(skillsAddCall![1]).toEqual({ cwd });
   });
 

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -43,7 +43,7 @@ export async function wireSkills(cwd: string): Promise<void> {
     const label = skill.workspace ? `workspace package ${log.skill(skill.name, skill.version)}` : log.skill(skill.name, skill.version);
     log.info(`Linking ${label} into agent directories`);
     try {
-      await npx(['skills', 'add', skill.skillDir, '--all', '-y'], { cwd });
+      await npx(['skills', 'add', skill.skillDir, '-y'], { cwd });
       log.success(`Linked ${skill.name}`);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Problem

Fixes #50

`skillpm install` was calling:

```
npx skills add <skillDir> --all -y
```

The `--all` flag bypasses agent auto-detection and installs skill files into all 37+ agent directories regardless of which agents the user has installed, polluting the workspace with directories for agents like Windsurf, OpenHands, etc. that the user may not use.

## Fix

Drop `--all`, keep `-y`:

```
npx skills add <skillDir> -y
```

The `skills` CLI then auto-detects which coding agents are present and only installs to those.

## Changes

- `src/commands/install.ts`: remove `--all` from `npx skills add` invocation
- `src/commands/install.test.ts`: assert `--all` is absent and `-y` is present