### PR TITLE
fix: use @sbroenne/add-mcp fork with idempotent config writes

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -63,7 +63,7 @@ export async function wireSkills(cwd: string): Promise<void> {
     for (const server of mcpServers) {
       log.info(`Configuring MCP server: ${server}`);
       try {
-        await npx(['add-mcp', server, '-y'], { cwd });
+        await npx(['@sbroenne/add-mcp', server, '-y'], { cwd });
         log.success(`Configured ${server}`);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -14,7 +14,7 @@ export async function mcp(
       for (const source of args) {
         log.info(`Configuring MCP server: ${source}`);
         try {
-          await npx(['add-mcp', source, '-y'], { cwd });
+          await npx(['@sbroenne/add-mcp', source, '-y'], { cwd });
           log.success(`Configured ${source}`);
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Switch from \dd-mcp\ to \@sbroenne/add-mcp\ which fixes config overwrite bugs: existing entries are preserved, URL duplicates are detected, and sibling JSON entries aren't reformatted on repeated runs.

Upstream PR: https://github.com/neondatabase/add-mcp/pull/12

Once upstream merges and publishes, swap back to \dd-mcp\.