### PR TITLE
Warn when packages contain multiple skills

### DIFF
--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -126,6 +126,33 @@ describe('wireSkills', () => {
     expect(skillsAddCalls[0][1]).toEqual({ cwd });
   });
 
+
+  it('warns when a package contains multiple skills but links only one', async () => {
+    const pkgDir = join(cwd, 'node_modules', 'multi-skill-package');
+    const firstSkillDir = join(pkgDir, 'skills', 'first-skill');
+    const secondSkillDir = join(pkgDir, 'skills', 'second-skill');
+    await mkdir(firstSkillDir, { recursive: true });
+    await mkdir(secondSkillDir, { recursive: true });
+    await writeFile(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ name: 'multi-skill-package', version: '1.0.0' }),
+    );
+    await writeFile(join(firstSkillDir, 'SKILL.md'), '---\nname: first-skill\ndescription: Test\n---\n');
+    await writeFile(join(secondSkillDir, 'SKILL.md'), '---\nname: second-skill\ndescription: Test\n---\n');
+
+    await wireSkills(cwd);
+
+    const skillsAddCalls = mockNpx.mock.calls.filter(
+      (call) => call[0][0] === 'skills' && call[0][1] === 'add',
+    );
+    expect(skillsAddCalls).toHaveLength(1);
+    expect(skillsAddCalls[0][0][2]).toBe(firstSkillDir);
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringContaining('multi-skill-package: multiple skills were found in one package.'),
+    );
+    expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining(secondSkillDir));
+  });
+
   it('warns for legacy root SKILL.md packages', async () => {
     const legacyDir = join(cwd, 'node_modules', 'legacy-skill');
     await mkdir(legacyDir, { recursive: true });

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -47,6 +47,11 @@ export async function wireSkills(cwd: string): Promise<void> {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(`Failed to link ${skill.name}: ${msg}`);
     }
+    if (skill.ignoredSkillDirs?.length) {
+      log.warn(
+        `${skill.name}: multiple skills were found in one package. skillpm links one skill per package; ignored ${skill.ignoredSkillDirs.join(', ')}.`,
+      );
+    }
     if (skill.legacy && !skill.workspace) {
       log.warn(
         `${skill.name}: SKILL.md is at package root. Move to skills/<name>/SKILL.md for full compatibility. See https://skillpm.dev/creating-skills/`,

--- a/src/manifest/schema.ts
+++ b/src/manifest/schema.ts
@@ -11,6 +11,8 @@ export interface SkillInfo {
   path: string;
   /** Path to the directory containing SKILL.md */
   skillDir: string;
+  /** Additional skill directories in the same package that were not linked. */
+  ignoredSkillDirs?: string[];
   /** True if SKILL.md is at package root instead of skills/<name>/ */
   legacy?: boolean;
   /** True when the package was found via a symlink in node_modules/. */

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -73,19 +73,25 @@ async function tryReadSkill(pkgDir: string, workspace = false): Promise<SkillInf
     skillSubdirs = [];
   }
 
+  const discoveredSkillDirs: string[] = [];
   for (const sub of skillSubdirs) {
     const skillDir = join(skillsDir, sub);
     try {
       await access(join(skillDir, 'SKILL.md'));
+      discoveredSkillDirs.push(skillDir);
     } catch {
       continue;
     }
+  }
 
+  if (discoveredSkillDirs.length > 0) {
+    const [skillDir, ...ignoredSkillDirs] = discoveredSkillDirs;
     return {
       name: pkg.name,
       version: pkg.version,
       path: pkgDir,
       skillDir,
+      ...(ignoredSkillDirs.length > 0 ? { ignoredSkillDirs } : {}),
       workspace: workspace || undefined,
     };
   }


### PR DESCRIPTION
## Summary

Warn when an npm package contains more than one `skills/*/SKILL.md` directory but `skillpm` links only the first discovered skill.

The docs currently say "one skill per npm package," which is clear. The install behavior was less clear: a multi-skill package is reported as one skill package and silently ignores the remaining skill directories. This can make registry/install state look complete when only one agent-visible skill was actually linked.

## Why

I hit this with `pluribus-context@0.3.41` while testing SkillPM discovery:

```bash
tmp=$(mktemp -d)
cd "$tmp"
npx --yes skillpm install pluribus-context --yes
find .agents/skills -maxdepth 2 -type f | sort
```

Expected from package contents: two shipped skills under `skills/context-receipts/` and `skills/skill-policy-receipts/`.

Observed: SkillPM found one skill package and linked only `.agents/skills/context-receipts`, with no warning that `skill-policy-receipts` was ignored.

## Change

- collect all valid `skills/*/SKILL.md` dirs inside a package
- keep current behavior: link the first one only
- add `ignoredSkillDirs` metadata for the remaining directories
- emit a warning naming ignored skill dirs so users can either split the package or install with a different tool
- add regression coverage

I kept this conservative instead of changing SkillPM to link all skills, because the current docs intentionally define one skill per npm package.

## Checks

- `npm run build`
- `npm test` — 37/37
- `npm run lint`
- `git diff --check`
